### PR TITLE
chore: upgrade to smithy-kotlin 1.6.15

### DIFF
--- a/.changes/9914b96a-77ea-4a9b-8c95-8e32409091fc.json
+++ b/.changes/9914b96a-77ea-4a9b-8c95-8e32409091fc.json
@@ -1,0 +1,5 @@
+{
+    "id": "9914b96a-77ea-4a9b-8c95-8e32409091fc",
+    "type": "bugfix",
+    "description": "Upgrade to **smithy-kotlin** release [**v1.6.15**](https://github.com/smithy-lang/smithy-kotlin/releases/tag/v1.6.15) to pick up serde bug fixes"
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ atomicfu-version = "0.33.0"
 binary-compatibility-validator-version = "0.18.1"
 
 # smithy-kotlin
-smithy-kotlin-version = "1.6.14"
+smithy-kotlin-version = "1.6.15"
 
 # codegen
 smithy-version = "1.71.0"


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Upgrade to **smithy-kotlin** release [**v1.6.15**](https://github.com/smithy-lang/smithy-kotlin/releases/tag/v1.6.15) to pick up the following serde bug fixes:
* https://github.com/smithy-lang/smithy-kotlin/pull/1611
* https://github.com/smithy-lang/smithy-kotlin/pull/1612
* https://github.com/smithy-lang/smithy-kotlin/pull/1613

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
