### PR TITLE
Expand Counter/TTL functionality to `UpdateItem`, `BatchWriteItem`, and `TransactWriteItems`

### DIFF
--- a/hll/ddb-mapper/dynamodb-mapper-ops-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/operations/model/Structure.kt
+++ b/hll/ddb-mapper/dynamodb-mapper-ops-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/operations/model/Structure.kt
@@ -86,6 +86,7 @@ private fun deriveExpressionLiteral(llMember: Member, type: ExpressionLiteralTyp
         ExpressionLiteralType.Update -> DslInfo(
             interfaceType = MapperTypes.Expressions.UpdateDsl,
             implType = MapperTypes.Expressions.Internal.UpdateDslImpl,
+            implInvocationStyle = DslInvocationStyle.Constructor("update"),
             implFinalizer = ".toExpression()",
         )
     }

--- a/hll/ddb-mapper/dynamodb-mapper-schema-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/annotations/rendering/SchemaRenderer.kt
+++ b/hll/ddb-mapper/dynamodb-mapper-schema-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/annotations/rendering/SchemaRenderer.kt
@@ -354,7 +354,7 @@ internal class SchemaRenderer(
                         require(lifetime > 0) { "@DynamoDbTtlSeconds must be positive, got $lifetime seconds on property ${prop.ddbName}" }
                         prop.simpleName.getShortName() to lifetime
                     }
-            }
+            }.toMap()
 
             // Handle Counter annotation
             val counterFields = properties.mapNotNull { prop ->
@@ -372,6 +372,13 @@ internal class SchemaRenderer(
             val hasAttributes = ttlFields.isNotEmpty() || counterFields.isNotEmpty()
 
             if (hasAttributes) {
+                if (ttlFields.isNotEmpty()) {
+                    val ttlFieldsCode = ttlFields.entries.joinToString { (fieldName, lifetime) ->
+                        format("#S to #LL", fieldName, lifetime)
+                    }
+                    write("private val ttlFields = #T(#L)", Types.Kotlin.Collections.mapOf, ttlFieldsCode)
+                }
+
                 withBlock(
                     "override val attributes: #T = #T {",
                     "}",
@@ -379,20 +386,16 @@ internal class SchemaRenderer(
                     Type.from(RuntimeTypes.Core.Collections.attributesOf),
                 ) {
                     if (ttlFields.isNotEmpty()) {
-                        writeInline("#T.#L to #T(", MapperTypes.Model.SchemaAttributes, "TtlFields", Types.Kotlin.Collections.setOf)
-                        ttlFields.forEachIndexed { index, (fieldName, lifetime) ->
-                            if (index > 0) writeInline(", ")
-                            writeInline("#T(#S, #LL)", Types.Kotlin.Pair, fieldName, lifetime)
-                        }
-                        write(")")
+                        write("#T.TtlFields to ttlFields", MapperTypes.Model.SchemaAttributes)
                     }
                     if (counterFields.isNotEmpty()) {
+                        val counterFieldsCode = counterFields.joinToString { format("#S", it) }
+
                         write(
-                            "#T.#L to #T(#L)",
+                            "#T.CounterFields to #T(#L)",
                             MapperTypes.Model.SchemaAttributes,
-                            "CounterFields",
                             Types.Kotlin.Collections.setOf,
-                            counterFields.joinToString(", ") { "\"$it\"" },
+                            counterFieldsCode,
                         )
                     }
                 }

--- a/hll/ddb-mapper/dynamodb-mapper-schema-generator-plugin/src/test/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/plugins/SchemaGeneratorPluginTest.kt
+++ b/hll/ddb-mapper/dynamodb-mapper-schema-generator-plugin/src/test/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/plugins/SchemaGeneratorPluginTest.kt
@@ -718,8 +718,9 @@ class SchemaGeneratorPluginTest {
             public object UserSchema : ItemSchema.PartitionKey<User, KeyType.Key1<Int>> {
                 override val converter: UserConverter = UserConverter
                 override val partitionKey: KeySpec.Key1<Int> = KeySpec.int("id")
+                private val ttlFields = mapOf("expiresAt" to 86400L)
                 override val attributes: Attributes = attributesOf {
-                    SchemaAttributes.TtlFields to setOf(Pair("expiresAt", 86400L))
+                    SchemaAttributes.TtlFields to ttlFields
                 }
             }
             """.trimIndent(),
@@ -753,8 +754,9 @@ class SchemaGeneratorPluginTest {
             public object MultipleTtlAnnotationsSchema : ItemSchema.PartitionKey<MultipleTtlAnnotations, KeyType.Key1<Int>> {
                 override val converter: MultipleTtlAnnotationsConverter = MultipleTtlAnnotationsConverter
                 override val partitionKey: KeySpec.Key1<Int> = KeySpec.int("id")
+                private val ttlFields = mapOf("expiresAt" to 3600L, "actuallyExpiresAt" to 7200L)
                 override val attributes: Attributes = attributesOf {
-                    SchemaAttributes.TtlFields to setOf(Pair("expiresAt", 3600L), Pair("actuallyExpiresAt", 7200L))
+                    SchemaAttributes.TtlFields to ttlFields
                 }
             }
             """.trimIndent(),
@@ -788,8 +790,9 @@ class SchemaGeneratorPluginTest {
             public object UserWithCounterSchema : ItemSchema.PartitionKey<UserWithCounter, KeyType.Key1<Int>> {
                 override val converter: UserWithCounterConverter = UserWithCounterConverter
                 override val partitionKey: KeySpec.Key1<Int> = KeySpec.int("id")
+                private val ttlFields = mapOf("expiresAt" to 3600L)
                 override val attributes: Attributes = attributesOf {
-                    SchemaAttributes.TtlFields to setOf(Pair("expiresAt", 3600L))
+                    SchemaAttributes.TtlFields to ttlFields
                     SchemaAttributes.CounterFields to setOf("accessCount", "updateCount")
                 }
             }

--- a/hll/ddb-mapper/dynamodb-mapper/api/dynamodb-mapper.api
+++ b/hll/ddb-mapper/dynamodb-mapper/api/dynamodb-mapper.api
@@ -937,13 +937,6 @@ public final class aws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateDsl$Set$D
 public abstract interface class aws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr : aws/sdk/kotlin/hll/dynamodbmapper/expressions/Expression {
 	public static final field Companion Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Companion;
 	public fun accept (Laws/sdk/kotlin/hll/dynamodbmapper/expressions/ExpressionVisitor;)Ljava/lang/Object;
-	public abstract fun getAdd ()Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Clause;
-	public abstract fun getDelete ()Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Clause;
-	public abstract fun getRemove ()Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Clause;
-	public abstract fun getSet ()Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Clause;
-}
-
-public abstract interface class aws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Clause {
 	public abstract fun getUpdates ()Ljava/util/List;
 }
 
@@ -955,9 +948,7 @@ public final class aws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Defa
 }
 
 public final class aws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExprKt {
-	public static final fun Clause (Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Companion;Ljava/util/List;)Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Clause;
-	public static final fun UpdateExpr (Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Clause;Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Clause;Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Clause;Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Clause;)Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr;
-	public static synthetic fun UpdateExpr$default (Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Clause;Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Clause;Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Clause;Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Clause;ILjava/lang/Object;)Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr;
+	public static final fun UpdateExpr (Ljava/util/List;)Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr;
 }
 
 public final class aws/sdk/kotlin/hll/dynamodbmapper/interceptors/CounterInterceptor : aws/sdk/kotlin/hll/dynamodbmapper/pipeline/Interceptor {

--- a/hll/ddb-mapper/dynamodb-mapper/api/dynamodb-mapper.api
+++ b/hll/ddb-mapper/dynamodb-mapper/api/dynamodb-mapper.api
@@ -957,6 +957,7 @@ public final class aws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Defa
 public final class aws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExprKt {
 	public static final fun Clause (Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Companion;Ljava/util/List;)Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Clause;
 	public static final fun UpdateExpr (Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Clause;Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Clause;Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Clause;Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Clause;)Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr;
+	public static synthetic fun UpdateExpr$default (Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Clause;Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Clause;Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Clause;Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr$Clause;ILjava/lang/Object;)Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr;
 }
 
 public final class aws/sdk/kotlin/hll/dynamodbmapper/interceptors/CounterInterceptor : aws/sdk/kotlin/hll/dynamodbmapper/pipeline/Interceptor {
@@ -1064,10 +1065,14 @@ public final class aws/sdk/kotlin/hll/dynamodbmapper/items/ItemSchema$PartitionK
 }
 
 public final class aws/sdk/kotlin/hll/dynamodbmapper/items/ItemSchemaKt {
-	public static final fun ItemSchema (Laws/sdk/kotlin/hll/mapping/core/converters/Converter;Laws/sdk/kotlin/hll/dynamodbmapper/items/KeySpec;)Laws/sdk/kotlin/hll/dynamodbmapper/items/ItemSchema$PartitionKey;
-	public static final fun ItemSchema (Laws/sdk/kotlin/hll/mapping/core/converters/Converter;Laws/sdk/kotlin/hll/dynamodbmapper/items/KeySpec;Laws/sdk/kotlin/hll/dynamodbmapper/items/KeySpec;)Laws/sdk/kotlin/hll/dynamodbmapper/items/ItemSchema$CompositeKey;
-	public static final fun withKeySpec (Laws/sdk/kotlin/hll/mapping/core/converters/Converter;Laws/sdk/kotlin/hll/dynamodbmapper/items/KeySpec;)Laws/sdk/kotlin/hll/dynamodbmapper/items/ItemSchema$PartitionKey;
-	public static final fun withKeySpec (Laws/sdk/kotlin/hll/mapping/core/converters/Converter;Laws/sdk/kotlin/hll/dynamodbmapper/items/KeySpec;Laws/sdk/kotlin/hll/dynamodbmapper/items/KeySpec;)Laws/sdk/kotlin/hll/dynamodbmapper/items/ItemSchema$CompositeKey;
+	public static final fun ItemSchema (Laws/sdk/kotlin/hll/mapping/core/converters/Converter;Laws/sdk/kotlin/hll/dynamodbmapper/items/KeySpec;Laws/sdk/kotlin/hll/dynamodbmapper/items/KeySpec;Laws/smithy/kotlin/runtime/collections/Attributes;)Laws/sdk/kotlin/hll/dynamodbmapper/items/ItemSchema$CompositeKey;
+	public static final fun ItemSchema (Laws/sdk/kotlin/hll/mapping/core/converters/Converter;Laws/sdk/kotlin/hll/dynamodbmapper/items/KeySpec;Laws/smithy/kotlin/runtime/collections/Attributes;)Laws/sdk/kotlin/hll/dynamodbmapper/items/ItemSchema$PartitionKey;
+	public static synthetic fun ItemSchema$default (Laws/sdk/kotlin/hll/mapping/core/converters/Converter;Laws/sdk/kotlin/hll/dynamodbmapper/items/KeySpec;Laws/sdk/kotlin/hll/dynamodbmapper/items/KeySpec;Laws/smithy/kotlin/runtime/collections/Attributes;ILjava/lang/Object;)Laws/sdk/kotlin/hll/dynamodbmapper/items/ItemSchema$CompositeKey;
+	public static synthetic fun ItemSchema$default (Laws/sdk/kotlin/hll/mapping/core/converters/Converter;Laws/sdk/kotlin/hll/dynamodbmapper/items/KeySpec;Laws/smithy/kotlin/runtime/collections/Attributes;ILjava/lang/Object;)Laws/sdk/kotlin/hll/dynamodbmapper/items/ItemSchema$PartitionKey;
+	public static final fun withKeySpec (Laws/sdk/kotlin/hll/mapping/core/converters/Converter;Laws/sdk/kotlin/hll/dynamodbmapper/items/KeySpec;Laws/sdk/kotlin/hll/dynamodbmapper/items/KeySpec;Laws/smithy/kotlin/runtime/collections/Attributes;)Laws/sdk/kotlin/hll/dynamodbmapper/items/ItemSchema$CompositeKey;
+	public static final fun withKeySpec (Laws/sdk/kotlin/hll/mapping/core/converters/Converter;Laws/sdk/kotlin/hll/dynamodbmapper/items/KeySpec;Laws/smithy/kotlin/runtime/collections/Attributes;)Laws/sdk/kotlin/hll/dynamodbmapper/items/ItemSchema$PartitionKey;
+	public static synthetic fun withKeySpec$default (Laws/sdk/kotlin/hll/mapping/core/converters/Converter;Laws/sdk/kotlin/hll/dynamodbmapper/items/KeySpec;Laws/sdk/kotlin/hll/dynamodbmapper/items/KeySpec;Laws/smithy/kotlin/runtime/collections/Attributes;ILjava/lang/Object;)Laws/sdk/kotlin/hll/dynamodbmapper/items/ItemSchema$CompositeKey;
+	public static synthetic fun withKeySpec$default (Laws/sdk/kotlin/hll/mapping/core/converters/Converter;Laws/sdk/kotlin/hll/dynamodbmapper/items/KeySpec;Laws/smithy/kotlin/runtime/collections/Attributes;ILjava/lang/Object;)Laws/sdk/kotlin/hll/dynamodbmapper/items/ItemSchema$PartitionKey;
 }
 
 public abstract interface class aws/sdk/kotlin/hll/dynamodbmapper/items/KeyAttrSpec {

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr.kt
@@ -4,8 +4,10 @@
  */
 package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.UpdateAddImpl
 import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.UpdateExprClauseImpl
 import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.UpdateExprImpl
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.UpdateSetImpl
 
 /**
  * Represents an
@@ -56,15 +58,15 @@ public interface UpdateExpr : Expression {
  * @param delete The `DELETE` clause of this expression
  */
 public fun UpdateExpr(
-    set: UpdateExpr.Clause,
-    remove: UpdateExpr.Clause,
-    add: UpdateExpr.Clause,
-    delete: UpdateExpr.Clause,
+    set: UpdateExpr.Clause = UpdateExprClauseImpl(),
+    remove: UpdateExpr.Clause = UpdateExprClauseImpl(),
+    add: UpdateExpr.Clause = UpdateExprClauseImpl(),
+    delete: UpdateExpr.Clause = UpdateExprClauseImpl(),
 ): UpdateExpr = UpdateExprImpl(set, remove, add, delete)
 
 /**
  * Creates an update expression clause
- * @param A list of update clause expressions which are associated with this clause
+ * @param updates A list of update clause expressions which are associated with this clause
  */
 public fun UpdateExpr.Companion.Clause(
     updates: List<UpdateClauseExpr>,

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr.kt
@@ -4,10 +4,7 @@
  */
 package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 
-import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.UpdateAddImpl
-import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.UpdateExprClauseImpl
 import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.UpdateExprImpl
-import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.UpdateSetImpl
 
 /**
  * Represents an
@@ -17,35 +14,7 @@ import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.UpdateSetImpl
 public interface UpdateExpr : Expression {
     public companion object { }
 
-    /**
-     * The `SET` clause of this expression
-     */
-    public val set: Clause
-
-    /**
-     * The `REMOVE` clause of this expression
-     */
-    public val remove: Clause
-
-    /**
-     * The `ADD` clause of this expression
-     */
-    public val add: Clause
-
-    /**
-     * The `DELETE` clause of this expression
-     */
-    public val delete: Clause
-
-    /**
-     * Represents a clause inside an update expression
-     */
-    public interface Clause {
-        /**
-         * A list of update clause expressions which are associated with this clause
-         */
-        public val updates: List<UpdateClauseExpr>
-    }
+    public val updates: List<UpdateClauseExpr>
 
     override fun <T> accept(visitor: ExpressionVisitor<T>): T = visitor.visit(this)
 }
@@ -57,17 +26,4 @@ public interface UpdateExpr : Expression {
  * @param add The `ADD` clause of this expression
  * @param delete The `DELETE` clause of this expression
  */
-public fun UpdateExpr(
-    set: UpdateExpr.Clause = UpdateExprClauseImpl(),
-    remove: UpdateExpr.Clause = UpdateExprClauseImpl(),
-    add: UpdateExpr.Clause = UpdateExprClauseImpl(),
-    delete: UpdateExpr.Clause = UpdateExprClauseImpl(),
-): UpdateExpr = UpdateExprImpl(set, remove, add, delete)
-
-/**
- * Creates an update expression clause
- * @param updates A list of update clause expressions which are associated with this clause
- */
-public fun UpdateExpr.Companion.Clause(
-    updates: List<UpdateClauseExpr>,
-): UpdateExpr.Clause = UpdateExprClauseImpl(updates)
+public fun UpdateExpr(updates: List<UpdateClauseExpr>): UpdateExpr = UpdateExprImpl(updates)

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/internal/AttributePathImpl.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/internal/AttributePathImpl.kt
@@ -8,14 +8,28 @@ import aws.sdk.kotlin.hll.dynamodbmapper.expressions.Attr
 import aws.sdk.kotlin.hll.dynamodbmapper.expressions.AttrPathElement
 import aws.sdk.kotlin.hll.dynamodbmapper.expressions.AttributePath
 
-internal data class AttrPathNameImpl(override val name: String) : AttrPathElement.Name
+internal data class AttrPathNameImpl(override val name: String) : AttrPathElement.Name {
+    override fun toString(): String = name
+}
 
-internal data class AttrPathIndexImpl(override val index: Int) : AttrPathElement.Index
+internal data class AttrPathIndexImpl(override val index: Int) : AttrPathElement.Index {
+    override fun toString(): String = "[$index]"
+}
 
 internal data class AttributePathImpl(
     override val element: AttrPathElement,
     override val parent: AttributePath? = null,
 ) : AttributePath {
+    private val dottedNotation by lazy {
+        buildString {
+            parent?.let { append(it.toString()) }
+            if (isNotEmpty() && element is AttrPathElement.Name) {
+                append('.')
+            }
+            append(element.toString())
+        }
+    }
+
     init {
         require(element is AttrPathElement.Name || parent != null) {
             "Top-level attribute paths must be names (not indices)"
@@ -24,6 +38,7 @@ internal data class AttributePathImpl(
 
     override fun get(index: Int) = AttributePath(index, parent = this)
     override fun get(key: String) = AttributePath(key, parent = this)
+    override fun toString(): String = dottedNotation
 }
 
 internal object AttrImpl : Attr {

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/internal/ParameterizingExpressionVisitor.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/internal/ParameterizingExpressionVisitor.kt
@@ -128,9 +128,10 @@ internal open class ParameterizingExpressionVisitor : ExpressionVisitor<String> 
     )
 
     override fun visit(expr: UpdateExpr): String = buildString {
-        fun appendClause(command: String, clause: UpdateExpr.Clause) {
-            val updates = clause.updates
-            if (updates.isNotEmpty()) {
+        val updates = expr.updates.groupBy { it.action }
+
+        fun appendClause(command: String, updates: List<UpdateClauseExpr>?) {
+            if (!updates.isNullOrEmpty()) {
                 append(command)
                 append(' ')
                 updates.joinTo(this) { it.accept() }
@@ -138,10 +139,10 @@ internal open class ParameterizingExpressionVisitor : ExpressionVisitor<String> 
             }
         }
 
-        appendClause("SET", expr.set)
-        appendClause("REMOVE", expr.remove)
-        appendClause("ADD", expr.add)
-        appendClause("DELETE", expr.delete)
+        appendClause("SET", updates[UpdateAction.SET])
+        appendClause("REMOVE", updates[UpdateAction.REMOVE])
+        appendClause("ADD", updates[UpdateAction.ADD])
+        appendClause("DELETE", updates[UpdateAction.DELETE])
     }.trim()
 
     override fun visit(expr: UpdateClauseExpr) = buildString {

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/internal/UpdateDslImpl.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/internal/UpdateDslImpl.kt
@@ -13,6 +13,14 @@ internal data class UpdateDslImpl(
     val add: UpdateAddImpl = UpdateAddImpl(),
     val delete: UpdateDeleteImpl = UpdateDeleteImpl(),
 ) : UpdateDsl {
+    constructor(updateExpr: UpdateExpr?) : this(updateExpr?.flatUpdates() ?: listOf())
+    constructor(updates: List<UpdateClauseExpr>) : this(
+        UpdateSetImpl(updates.filter { it.action == UpdateAction.SET }),
+        UpdateRemoveImpl(updates.filter { it.action == UpdateAction.REMOVE }),
+        UpdateAddImpl(updates.filter { it.action == UpdateAction.ADD }),
+        UpdateDeleteImpl(updates.filter { it.action == UpdateAction.DELETE }),
+    )
+
     override fun set(block: UpdateDsl.Set.() -> Unit) = set.block()
     override fun remove(block: UpdateDsl.Remove.() -> Unit) = remove.block()
     override fun add(block: UpdateDsl.Add.() -> Unit) = add.block()
@@ -26,8 +34,8 @@ internal data class UpdateDslImpl(
     )
 }
 
-internal abstract class UpdateClauseImpl(val action: UpdateAction) {
-    private val _updates = mutableListOf<UpdateClauseExpr>()
+internal abstract class UpdateClauseImpl(val action: UpdateAction, updates: List<UpdateClauseExpr> = listOf()) {
+    private val _updates = updates.toMutableList()
     val updates: List<UpdateClauseExpr> get() = _updates
 
     fun AttributePath.update(value: Expression) {
@@ -35,8 +43,8 @@ internal abstract class UpdateClauseImpl(val action: UpdateAction) {
     }
 }
 
-internal class UpdateSetImpl :
-    UpdateClauseImpl(UpdateAction.SET),
+internal class UpdateSetImpl(updates: List<UpdateClauseExpr> = listOf()) :
+    UpdateClauseImpl(UpdateAction.SET, updates),
     UpdateDsl.Set {
 
     override val attr = AttrImpl
@@ -66,8 +74,8 @@ internal class UpdateSetImpl :
     ): Expression = AdditiveExpr(AdditiveOperation.SUBTRACT, this, value)
 }
 
-internal class UpdateRemoveImpl :
-    UpdateClauseImpl(UpdateAction.REMOVE),
+internal class UpdateRemoveImpl(updates: List<UpdateClauseExpr> = listOf()) :
+    UpdateClauseImpl(UpdateAction.REMOVE, updates),
     UpdateDsl.Remove {
 
     override val attr = AttrImpl
@@ -75,8 +83,8 @@ internal class UpdateRemoveImpl :
     override fun AttributePath.unaryMinus() = update(LiteralExpr(null))
 }
 
-internal class UpdateAddImpl :
-    UpdateClauseImpl(UpdateAction.ADD),
+internal class UpdateAddImpl(updates: List<UpdateClauseExpr> = listOf()) :
+    UpdateClauseImpl(UpdateAction.ADD, updates),
     UpdateDsl.Add {
 
     override val attr: Attr = AttrImpl
@@ -84,11 +92,13 @@ internal class UpdateAddImpl :
     override fun AttributePath.plusAssign(value: Expression) = update(value)
 }
 
-internal class UpdateDeleteImpl :
-    UpdateClauseImpl(UpdateAction.DELETE),
+internal class UpdateDeleteImpl(updates: List<UpdateClauseExpr> = listOf()) :
+    UpdateClauseImpl(UpdateAction.DELETE, updates),
     UpdateDsl.Delete {
 
     override val attr: Attr = AttrImpl
 
     override fun AttributePath.minusAssign(value: Expression) = update(value)
 }
+
+private fun UpdateExpr.flatUpdates() = listOf(set, remove, add, delete).flatMap { it.updates }

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/internal/UpdateDslImpl.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/internal/UpdateDslImpl.kt
@@ -7,43 +7,39 @@ package aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal
 
 import aws.sdk.kotlin.hll.dynamodbmapper.expressions.*
 
-internal data class UpdateDslImpl(
-    val set: UpdateSetImpl = UpdateSetImpl(),
-    val remove: UpdateRemoveImpl = UpdateRemoveImpl(),
-    val add: UpdateAddImpl = UpdateAddImpl(),
-    val delete: UpdateDeleteImpl = UpdateDeleteImpl(),
+internal class UpdateDslImpl(
+    private val updates: MutableMap<AttributePath, UpdateClauseExpr> = mutableMapOf(),
 ) : UpdateDsl {
-    constructor(updateExpr: UpdateExpr?) : this(updateExpr?.flatUpdates() ?: listOf())
-    constructor(updates: List<UpdateClauseExpr>) : this(
-        UpdateSetImpl(updates.filter { it.action == UpdateAction.SET }),
-        UpdateRemoveImpl(updates.filter { it.action == UpdateAction.REMOVE }),
-        UpdateAddImpl(updates.filter { it.action == UpdateAction.ADD }),
-        UpdateDeleteImpl(updates.filter { it.action == UpdateAction.DELETE }),
-    )
+    constructor(updateExpr: UpdateExpr?) : this(updateExpr?.updates ?: listOf())
+    constructor(updates: List<UpdateClauseExpr>) : this(updates.associateBy { it.target }.toMutableMap())
+
+    private val set = UpdateSetImpl(updates)
+    private val remove = UpdateRemoveImpl(updates)
+    private val add = UpdateAddImpl(updates)
+    private val delete = UpdateDeleteImpl(updates)
 
     override fun set(block: UpdateDsl.Set.() -> Unit) = set.block()
     override fun remove(block: UpdateDsl.Remove.() -> Unit) = remove.block()
     override fun add(block: UpdateDsl.Add.() -> Unit) = add.block()
     override fun delete(block: UpdateDsl.Delete.() -> Unit) = delete.block()
 
-    fun toExpression(): UpdateExpr = UpdateExpr(
-        UpdateExpr.Clause(set.updates),
-        UpdateExpr.Clause(remove.updates),
-        UpdateExpr.Clause(add.updates),
-        UpdateExpr.Clause(delete.updates),
-    )
+    fun toExpression(): UpdateExpr = UpdateExpr(updates.values.toList())
 }
 
-internal abstract class UpdateClauseImpl(val action: UpdateAction, updates: List<UpdateClauseExpr> = listOf()) {
-    private val _updates = updates.toMutableList()
-    val updates: List<UpdateClauseExpr> get() = _updates
-
+internal abstract class UpdateClauseImpl(
+    val action: UpdateAction,
+    private val updates: MutableMap<AttributePath, UpdateClauseExpr>,
+) {
     fun AttributePath.update(value: Expression) {
-        _updates += UpdateClauseExpr(action, this, value)
+        val clauseExp = UpdateClauseExpr(action, this, value)
+        val previousUpdate = updates.put(clauseExp.target, clauseExp)
+        if (previousUpdate != null) {
+            println("Warning: Replacing previous update of ${previousUpdate.target}") // FIXME log a proper warning
+        }
     }
 }
 
-internal class UpdateSetImpl(updates: List<UpdateClauseExpr> = listOf()) :
+internal class UpdateSetImpl(updates: MutableMap<AttributePath, UpdateClauseExpr>) :
     UpdateClauseImpl(UpdateAction.SET, updates),
     UpdateDsl.Set {
 
@@ -74,7 +70,7 @@ internal class UpdateSetImpl(updates: List<UpdateClauseExpr> = listOf()) :
     ): Expression = AdditiveExpr(AdditiveOperation.SUBTRACT, this, value)
 }
 
-internal class UpdateRemoveImpl(updates: List<UpdateClauseExpr> = listOf()) :
+internal class UpdateRemoveImpl(updates: MutableMap<AttributePath, UpdateClauseExpr>) :
     UpdateClauseImpl(UpdateAction.REMOVE, updates),
     UpdateDsl.Remove {
 
@@ -83,7 +79,7 @@ internal class UpdateRemoveImpl(updates: List<UpdateClauseExpr> = listOf()) :
     override fun AttributePath.unaryMinus() = update(LiteralExpr(null))
 }
 
-internal class UpdateAddImpl(updates: List<UpdateClauseExpr> = listOf()) :
+internal class UpdateAddImpl(updates: MutableMap<AttributePath, UpdateClauseExpr>) :
     UpdateClauseImpl(UpdateAction.ADD, updates),
     UpdateDsl.Add {
 
@@ -92,7 +88,7 @@ internal class UpdateAddImpl(updates: List<UpdateClauseExpr> = listOf()) :
     override fun AttributePath.plusAssign(value: Expression) = update(value)
 }
 
-internal class UpdateDeleteImpl(updates: List<UpdateClauseExpr> = listOf()) :
+internal class UpdateDeleteImpl(updates: MutableMap<AttributePath, UpdateClauseExpr>) :
     UpdateClauseImpl(UpdateAction.DELETE, updates),
     UpdateDsl.Delete {
 
@@ -100,5 +96,3 @@ internal class UpdateDeleteImpl(updates: List<UpdateClauseExpr> = listOf()) :
 
     override fun AttributePath.minusAssign(value: Expression) = update(value)
 }
-
-private fun UpdateExpr.flatUpdates() = listOf(set, remove, add, delete).flatMap { it.updates }

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/internal/UpdateExprImpl.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/internal/UpdateExprImpl.kt
@@ -14,4 +14,4 @@ internal data class UpdateExprImpl(
     override val delete: UpdateExpr.Clause,
 ) : UpdateExpr
 
-internal data class UpdateExprClauseImpl(override val updates: List<UpdateClauseExpr>) : UpdateExpr.Clause
+internal data class UpdateExprClauseImpl(override val updates: List<UpdateClauseExpr> = listOf()) : UpdateExpr.Clause

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/internal/UpdateExprImpl.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/internal/UpdateExprImpl.kt
@@ -7,11 +7,4 @@ package aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal
 import aws.sdk.kotlin.hll.dynamodbmapper.expressions.UpdateClauseExpr
 import aws.sdk.kotlin.hll.dynamodbmapper.expressions.UpdateExpr
 
-internal data class UpdateExprImpl(
-    override val set: UpdateExpr.Clause,
-    override val remove: UpdateExpr.Clause,
-    override val add: UpdateExpr.Clause,
-    override val delete: UpdateExpr.Clause,
-) : UpdateExpr
-
-internal data class UpdateExprClauseImpl(override val updates: List<UpdateClauseExpr> = listOf()) : UpdateExpr.Clause
+internal data class UpdateExprImpl(override val updates: List<UpdateClauseExpr>) : UpdateExpr

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/CounterInterceptor.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/CounterInterceptor.kt
@@ -5,79 +5,230 @@
 
 package aws.sdk.kotlin.hll.dynamodbmapper.interceptors
 
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.UpdateExpr
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.UpdateDslImpl
 import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
+import aws.sdk.kotlin.hll.dynamodbmapper.items.KeyType
 import aws.sdk.kotlin.hll.dynamodbmapper.model.SchemaAttributes
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.BatchWriteItemRequest
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.BatchWriteItemRequestTable
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.TransactWriteItemsAction
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.TransactWriteItemsRequest
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.TransactWriteItemsRequestTable
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.Update
 import aws.sdk.kotlin.hll.dynamodbmapper.operations.UpdateItemRequest
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.copy
 import aws.sdk.kotlin.hll.dynamodbmapper.operations.toBuilder
 import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.HReqContext
 import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.InterceptorAny
 import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.LReqContext
 import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.SerializeInput
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
+import aws.sdk.kotlin.services.dynamodb.model.BatchWriteItemRequest as LowLevelBatchWriteItemRequest
 import aws.sdk.kotlin.services.dynamodb.model.PutItemRequest as LowLevelPutItemRequest
+import aws.sdk.kotlin.services.dynamodb.model.TransactWriteItemsRequest as LowLevelTransactWriteItemsRequest
 
 /**
  * Interceptor that handles counter fields defined on schema attributes by incrementing them on each mutating operation.
- * This affects two operations:
- * * `PutItem` is intercepted in [modifyBeforeInvocation] to update the low-level request with the field names and their
- *   calculated values
- * * `UpdateItem` is intercepted in [modifyBeforeSerialization] to update the high-level request using the update
- *   expression
+ * This affects the following operations:
+ * * `PutItem` is intercepted in [modifyBeforeInvocation] to update the low-level request item with the incremented
+ *   field values
+ * * `UpdateItem` is intercepted in [modifyBeforeSerialization] to augment the high-level request's update expression
+ * * `BatchWriteItem` is intercepted in [modifyBeforeInvocation] to update the items of each low-level put request
+ * * `TransactWriteItems` is intercepted in both [modifyBeforeSerialization] (to augment the update expression of each
+ *   `Update` action) and [modifyBeforeInvocation] (to update the items of each low-level `Put` action)
+ *
+ * Counter fields are read from the schema associated with each operation. For the single-item operations this is the
+ * operation's [serialize schema][HReqContext.serializeSchema]; for the multi-table operations (`BatchWriteItem` and
+ * `TransactWriteItems`) the operation-level schema is a placeholder, so the per-table schemas carried by the request
+ * are used instead.
  */
 public class CounterInterceptor : InterceptorAny {
-    override fun modifyBeforeInvocation(ctx: LReqContext<Any, ItemSchema<Any>, Any, Any>): Any {
-        val counterFields = ctx.serializeSchema.attributes.getOrNull(SchemaAttributes.CounterFields) ?: return ctx.lowLevelRequest
-
-        return when (val originalReq = ctx.lowLevelRequest) {
-            is LowLevelPutItemRequest -> handlePutItem(originalReq, counterFields)
-            else -> originalReq
+    override fun modifyBeforeInvocation(ctx: LReqContext<Any, ItemSchema<Any>, Any, Any>): Any = when (val originalReq = ctx.lowLevelRequest) {
+        is LowLevelPutItemRequest -> {
+            val counterFields = ctx.serializeSchema.attributes.getOrNull(SchemaAttributes.CounterFields)
+                ?: return originalReq
+            handlePutItem(originalReq, counterFields)
         }
+
+        is LowLevelBatchWriteItemRequest ->
+            handleBatchWriteItem(originalReq, ctx.highLevelRequest as BatchWriteItemRequest)
+
+        is LowLevelTransactWriteItemsRequest ->
+            handleTransactWriteItems(originalReq, ctx.highLevelRequest as TransactWriteItemsRequest)
+
+        else -> originalReq
     }
 
-    override fun modifyBeforeSerialization(ctx: HReqContext<Any, ItemSchema<Any>, Any>): SerializeInput<Any, ItemSchema<Any>, Any> {
-        val counterFields = ctx.serializeSchema.attributes.getOrNull(SchemaAttributes.CounterFields) ?: return ctx
-
-        val updatedReq = when (val originalReq = ctx.highLevelRequest) {
-            is UpdateItemRequest -> handleUpdateItem(originalReq, counterFields)
-            else -> return ctx
+    override fun modifyBeforeSerialization(ctx: HReqContext<Any, ItemSchema<Any>, Any>): SerializeInput<Any, ItemSchema<Any>, Any> = when (val originalReq = ctx.highLevelRequest) {
+        is UpdateItemRequest -> {
+            val counterFields = ctx.serializeSchema.attributes.getOrNull(SchemaAttributes.CounterFields)
+                ?: return ctx
+            SerializeInput(handleUpdateItem(originalReq, counterFields), ctx.serializeSchema)
         }
 
-        return SerializeInput(updatedReq, ctx.serializeSchema)
+        is TransactWriteItemsRequest -> {
+            if (originalReq.tables.none { it.itemSchema.counterFields.isNotEmpty() }) return ctx
+            SerializeInput(handleTransactWriteItemsUpdates(originalReq), ctx.serializeSchema)
+        }
+
+        else -> ctx
     }
 
     private fun handlePutItem(request: LowLevelPutItemRequest, counterFields: Set<String>): LowLevelPutItemRequest {
-        val item = request.item?.toMutableMap() ?: return request
+        val item = request.item ?: return request
+        return request.copy { this.item = incrementCounters(item, counterFields) }
+    }
 
-        counterFields.forEach { fieldName ->
-            val currentValue = item[fieldName]?.asN()?.toLong() ?: 0L
-            item[fieldName] = AttributeValue.N((currentValue + 1).toString())
+    private fun handleBatchWriteItem(
+        request: LowLevelBatchWriteItemRequest,
+        highLevelRequest: BatchWriteItemRequest,
+    ): LowLevelBatchWriteItemRequest {
+        val counterFieldsByTable = highLevelRequest.tables
+            .associate { it.tableName to it.itemSchema.counterFields }
+            .filterValues { it.isNotEmpty() }
+
+        if (counterFieldsByTable.isEmpty()) return request
+
+        return request.copy {
+            requestItems = request.requestItems?.mapValues { (tableName, writeRequests) ->
+                val counterFields = counterFieldsByTable[tableName] ?: return@mapValues writeRequests
+                writeRequests.map { writeRequest ->
+                    val putRequest = writeRequest.putRequest ?: return@map writeRequest // leave delete requests untouched
+                    writeRequest.copy {
+                        this.putRequest = putRequest.copy { item = incrementCounters(putRequest.item, counterFields) }
+                    }
+                }
+            }
         }
+    }
 
-        return request.copy { this.item = item }
+    private fun handleTransactWriteItems(
+        request: LowLevelTransactWriteItemsRequest,
+        highLevelRequest: TransactWriteItemsRequest,
+    ): LowLevelTransactWriteItemsRequest {
+        val counterFieldsByTable = highLevelRequest.tables
+            .associate { it.tableName to it.itemSchema.counterFields }
+            .filterValues { it.isNotEmpty() }
+
+        if (counterFieldsByTable.isEmpty()) return request
+
+        return request.copy {
+            transactItems = request.transactItems?.map { transactItem ->
+                val put = transactItem.put ?: return@map transactItem // only `Put` actions; `Update` is handled high-level
+                val counterFields = counterFieldsByTable[put.tableName] ?: return@map transactItem
+                transactItem.copy { this.put = put.copy { item = incrementCounters(put.item, counterFields) } }
+            }
+        }
     }
 
     private fun handleUpdateItem(
         request: UpdateItemRequest,
         counterFields: Set<String>,
     ): UpdateItemRequest = when (request) {
-        is UpdateItemRequest.PartitionKey<*> -> request.toBuilder().apply {
-            update {
-                set {
-                    counterFields.forEach { fieldName ->
-                        attr[fieldName] = attr[fieldName].orElse(0) + 1
-                    }
-                }
-            }
-        }.build()
+        is UpdateItemRequest.PartitionKey<*> ->
+            request.toBuilder().apply { update = augmentUpdateExpr(update, counterFields) }.build()
 
-        is UpdateItemRequest.CompositeKey<*, *> -> request.toBuilder().apply {
-            update {
-                set {
-                    counterFields.forEach { fieldName ->
-                        attr[fieldName] = attr[fieldName].orElse(0) + 1
-                    }
-                }
-            }
-        }.build()
+        is UpdateItemRequest.CompositeKey<*, *> ->
+            request.toBuilder().apply { update = augmentUpdateExpr(update, counterFields) }.build()
     }
+
+    private fun handleTransactWriteItemsUpdates(request: TransactWriteItemsRequest): TransactWriteItemsRequest {
+        val newTables = request.tables.map { table ->
+            val counterFields = table.itemSchema.counterFields
+            if (counterFields.isEmpty()) table else augmentTableUpdates(table, counterFields)
+        }
+        return request.copy { tables = newTables }
+    }
+
+    private fun augmentTableUpdates(
+        table: TransactWriteItemsRequestTable<*>,
+        counterFields: Set<String>,
+    ): TransactWriteItemsRequestTable<*> = when (table) {
+        is TransactWriteItemsRequestTable.PartitionKey<*, *> -> augmentPartitionKeyTable(table, counterFields)
+        is TransactWriteItemsRequestTable.CompositeKey<*, *, *> -> augmentCompositeKeyTable(table, counterFields)
+    }
+
+    private fun <T, PK : KeyType> augmentPartitionKeyTable(
+        table: TransactWriteItemsRequestTable.PartitionKey<T, PK>,
+        counterFields: Set<String>,
+    ): TransactWriteItemsRequestTable.PartitionKey<T, PK> = if (table.updates.isEmpty()) {
+        table
+    } else {
+        TransactWriteItemsRequestTable(
+            conditionChecks = table.conditionChecks,
+            deletes = table.deletes,
+            puts = table.puts,
+            schema = table.schema,
+            tableName = table.tableName,
+            updates = table.updates.map { it.augment(counterFields) },
+        )
+    }
+
+    private fun <T, PK : KeyType, SK : KeyType> augmentCompositeKeyTable(
+        table: TransactWriteItemsRequestTable.CompositeKey<T, PK, SK>,
+        counterFields: Set<String>,
+    ): TransactWriteItemsRequestTable.CompositeKey<T, PK, SK> = if (table.updates.isEmpty()) {
+        table
+    } else {
+        TransactWriteItemsRequestTable(
+            conditionChecks = table.conditionChecks,
+            deletes = table.deletes,
+            puts = table.puts,
+            schema = table.schema,
+            tableName = table.tableName,
+            updates = table.updates.map { it.augment(counterFields) },
+        )
+    }
+
+    private fun <E> TransactWriteItemsAction.Update<E>.augment(
+        counterFields: Set<String>,
+    ): TransactWriteItemsAction.Update<E> = TransactWriteItemsAction.Update(
+        condition = condition,
+        entity = entity,
+        returnValuesOnConditionCheckFailure = returnValuesOnConditionCheckFailure,
+        update = augmentUpdateExpr(update, counterFields),
+    )
+
+    /**
+     * Increments each counter field in [item], defaulting any missing or null field to zero before incrementing.
+     */
+    private fun incrementCounters(
+        item: Map<String, AttributeValue>,
+        counterFields: Set<String>,
+    ): Map<String, AttributeValue> {
+        val newItem = item.toMutableMap()
+        counterFields.forEach { fieldName ->
+            val currentValue = newItem[fieldName]?.asN()?.toLong() ?: 0L
+            newItem[fieldName] = AttributeValue.N((currentValue + 1).toString())
+        }
+        return newItem
+    }
+
+    /**
+     * Returns a new [UpdateExpr] which augments [existing] with a `SET` clause incrementing each counter field via
+     * `if_not_exists(field, 0) + 1`.
+     */
+    private fun augmentUpdateExpr(existing: UpdateExpr?, counterFields: Set<String>): UpdateExpr = UpdateDslImpl(existing).apply {
+        set {
+            counterFields.forEach { fieldName ->
+                attr[fieldName] = attr[fieldName].orElse(0) + 1
+            }
+        }
+    }.toExpression()
 }
+
+private val ItemSchema<*>.counterFields: Set<String>
+    get() = attributes.getOrNull(SchemaAttributes.CounterFields).orEmpty()
+
+private val BatchWriteItemRequestTable<*>.itemSchema: ItemSchema<*>
+    get() = when (this) {
+        is BatchWriteItemRequestTable.PartitionKey<*, *> -> schema
+        is BatchWriteItemRequestTable.CompositeKey<*, *, *> -> schema
+    }
+
+private val TransactWriteItemsRequestTable<*>.itemSchema: ItemSchema<*>
+    get() = when (this) {
+        is TransactWriteItemsRequestTable.PartitionKey<*, *> -> schema
+        is TransactWriteItemsRequestTable.CompositeKey<*, *, *> -> schema
+    }

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/CounterInterceptor.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/CounterInterceptor.kt
@@ -7,33 +7,77 @@ package aws.sdk.kotlin.hll.dynamodbmapper.interceptors
 
 import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
 import aws.sdk.kotlin.hll.dynamodbmapper.model.SchemaAttributes
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.UpdateItemRequest
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.toBuilder
+import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.HReqContext
 import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.InterceptorAny
 import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.LReqContext
+import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.SerializeInput
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
 import aws.sdk.kotlin.services.dynamodb.model.PutItemRequest as LowLevelPutItemRequest
 
 /**
- * Interceptor that handles counter fields defined on schema attributes by incrementing them on each mutating operation
+ * Interceptor that handles counter fields defined on schema attributes by incrementing them on each mutating operation.
+ * This affects two operations:
+ * * `PutItem` is intercepted in [modifyBeforeInvocation] to update the low-level request with the field names and their
+ *   calculated values
+ * * `UpdateItem` is intercepted in [modifyBeforeSerialization] to update the high-level request using the update
+ *   expression
  */
 public class CounterInterceptor : InterceptorAny {
     override fun modifyBeforeInvocation(ctx: LReqContext<Any, ItemSchema<Any>, Any, Any>): Any {
         val counterFields = ctx.serializeSchema.attributes.getOrNull(SchemaAttributes.CounterFields) ?: return ctx.lowLevelRequest
 
-        return when (val request = ctx.lowLevelRequest) {
-            is LowLevelPutItemRequest -> handlePutItem(request, counterFields)
-            // TODO Support UpdateItem
-            else -> request
+        return when (val originalReq = ctx.lowLevelRequest) {
+            is LowLevelPutItemRequest -> handlePutItem(originalReq, counterFields)
+            else -> originalReq
         }
     }
 
-    private fun handlePutItem(request: LowLevelPutItemRequest, counterFields: Set<String>): LowLevelPutItemRequest {
-        val newItem = request.item?.toMutableMap() ?: return request
+    override fun modifyBeforeSerialization(ctx: HReqContext<Any, ItemSchema<Any>, Any>): SerializeInput<Any, ItemSchema<Any>, Any> {
+        val counterFields = ctx.serializeSchema.attributes.getOrNull(SchemaAttributes.CounterFields) ?: return ctx
 
-        counterFields.forEach { fieldName ->
-            val currentValue = newItem[fieldName]?.asN()?.toLong() ?: 0L
-            newItem[fieldName] = AttributeValue.N((currentValue + 1).toString())
+        val updatedReq = when (val originalReq = ctx.highLevelRequest) {
+            is UpdateItemRequest -> handleUpdateItem(originalReq, counterFields)
+            else -> return ctx
         }
 
-        return request.copy { item = newItem }
+        return SerializeInput(updatedReq, ctx.serializeSchema)
+    }
+
+    private fun handlePutItem(request: LowLevelPutItemRequest, counterFields: Set<String>): LowLevelPutItemRequest {
+        val item = request.item?.toMutableMap() ?: return request
+
+        counterFields.forEach { fieldName ->
+            val currentValue = item[fieldName]?.asN()?.toLong() ?: 0L
+            item[fieldName] = AttributeValue.N((currentValue + 1).toString())
+        }
+
+        return request.copy { this.item = item }
+    }
+
+    private fun handleUpdateItem(
+        request: UpdateItemRequest,
+        counterFields: Set<String>,
+    ): UpdateItemRequest = when (request) {
+        is UpdateItemRequest.PartitionKey<*> -> request.toBuilder().apply {
+            update {
+                set {
+                    counterFields.forEach { fieldName ->
+                        attr[fieldName] = attr[fieldName].orElse(0) + 1
+                    }
+                }
+            }
+        }.build()
+
+        is UpdateItemRequest.CompositeKey<*, *> -> request.toBuilder().apply {
+            update {
+                set {
+                    counterFields.forEach { fieldName ->
+                        attr[fieldName] = attr[fieldName].orElse(0) + 1
+                    }
+                }
+            }
+        }.build()
     }
 }

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/TtlInterceptor.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/TtlInterceptor.kt
@@ -7,34 +7,78 @@ package aws.sdk.kotlin.hll.dynamodbmapper.interceptors
 
 import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
 import aws.sdk.kotlin.hll.dynamodbmapper.model.SchemaAttributes
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.UpdateItemRequest
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.toBuilder
+import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.HReqContext
 import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.InterceptorAny
 import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.LReqContext
+import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.SerializeInput
 import aws.sdk.kotlin.hll.dynamodbmapper.util.av
 import aws.smithy.kotlin.runtime.time.Clock
 import aws.sdk.kotlin.services.dynamodb.model.PutItemRequest as LowLevelPutItemRequest
 
 /**
- * Interceptor that handles TTL fields defined on schema attributes and sets them to the current time plus their specified lifetimes.
+ * Interceptor that handles TTL fields defined on schema attributes and sets them to the current time plus their
+ * specified lifetimes. This affects two operations:
+ * * `PutItem` is intercepted in [modifyBeforeInvocation] to update the low-level request with the field names and their
+ *   calculated values
+ * * `UpdateItem` is intercepted in [modifyBeforeSerialization] to update the high-level request using the update
+ *   expression
  */
 public class TtlInterceptor(private val clock: Clock = Clock.System) : InterceptorAny {
     override fun modifyBeforeInvocation(ctx: LReqContext<Any, ItemSchema<Any>, Any, Any>): Any {
         val ttlFields = ctx.serializeSchema.attributes.getOrNull(SchemaAttributes.TtlFields) ?: return ctx.lowLevelRequest
 
-        return when (val request = ctx.lowLevelRequest) {
-            is LowLevelPutItemRequest -> handlePutItem(request, ttlFields)
-            // TODO Support UpdateItem
-            else -> request
+        return when (val originalReq = ctx.lowLevelRequest) {
+            is LowLevelPutItemRequest -> handlePutItem(originalReq, ttlFields)
+            else -> originalReq
         }
     }
 
-    private fun handlePutItem(request: LowLevelPutItemRequest, ttlFields: Set<Pair<String, Long>>): LowLevelPutItemRequest {
-        val newItem = request.item?.toMutableMap() ?: return request
+    override fun modifyBeforeSerialization(ctx: HReqContext<Any, ItemSchema<Any>, Any>): SerializeInput<Any, ItemSchema<Any>, Any> {
+        val ttlFields = ctx.serializeSchema.attributes.getOrNull(SchemaAttributes.TtlFields) ?: return ctx
+
+        val updatedReq = when (val originalReq = ctx.highLevelRequest) {
+            is UpdateItemRequest -> handleUpdateItem(originalReq, ttlFields)
+            else -> return ctx
+        }
+
+        return SerializeInput(updatedReq, ctx.serializeSchema)
+    }
+
+    private fun handlePutItem(request: LowLevelPutItemRequest, ttlFields: Map<String, Long>): LowLevelPutItemRequest {
+        val item = request.item?.toMutableMap() ?: return request
 
         ttlFields.forEach { (fieldName, lifetime) ->
             val ttlValue = av(clock.now().epochSeconds + lifetime)
-            newItem[fieldName] = ttlValue
+            item[fieldName] = ttlValue
         }
 
-        return request.copy { item = newItem }
+        return request.copy { this.item = item }
+    }
+
+    private fun handleUpdateItem(
+        request: UpdateItemRequest,
+        ttlFields: Map<String, Long>,
+    ): UpdateItemRequest = when (request) {
+        is UpdateItemRequest.PartitionKey<*> -> request.toBuilder().apply {
+            update {
+                set {
+                    ttlFields.forEach { (fieldName, lifetime) ->
+                        attr[fieldName] = clock.now().epochSeconds + lifetime
+                    }
+                }
+            }
+        }.build()
+
+        is UpdateItemRequest.CompositeKey<*, *> -> request.toBuilder().apply {
+            update {
+                set {
+                    ttlFields.forEach { (fieldName, lifetime) ->
+                        attr[fieldName] = clock.now().epochSeconds + lifetime
+                    }
+                }
+            }
+        }.build()
     }
 }

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/TtlInterceptor.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/TtlInterceptor.kt
@@ -5,80 +5,235 @@
 
 package aws.sdk.kotlin.hll.dynamodbmapper.interceptors
 
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.UpdateExpr
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.UpdateDslImpl
 import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
+import aws.sdk.kotlin.hll.dynamodbmapper.items.KeyType
 import aws.sdk.kotlin.hll.dynamodbmapper.model.SchemaAttributes
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.BatchWriteItemRequest
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.BatchWriteItemRequestTable
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.TransactWriteItemsAction
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.TransactWriteItemsRequest
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.TransactWriteItemsRequestTable
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.Update
 import aws.sdk.kotlin.hll.dynamodbmapper.operations.UpdateItemRequest
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.copy
 import aws.sdk.kotlin.hll.dynamodbmapper.operations.toBuilder
 import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.HReqContext
 import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.InterceptorAny
 import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.LReqContext
 import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.SerializeInput
 import aws.sdk.kotlin.hll.dynamodbmapper.util.av
+import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
 import aws.smithy.kotlin.runtime.time.Clock
+import aws.sdk.kotlin.services.dynamodb.model.BatchWriteItemRequest as LowLevelBatchWriteItemRequest
 import aws.sdk.kotlin.services.dynamodb.model.PutItemRequest as LowLevelPutItemRequest
+import aws.sdk.kotlin.services.dynamodb.model.TransactWriteItemsRequest as LowLevelTransactWriteItemsRequest
 
 /**
  * Interceptor that handles TTL fields defined on schema attributes and sets them to the current time plus their
- * specified lifetimes. This affects two operations:
- * * `PutItem` is intercepted in [modifyBeforeInvocation] to update the low-level request with the field names and their
- *   calculated values
- * * `UpdateItem` is intercepted in [modifyBeforeSerialization] to update the high-level request using the update
- *   expression
+ * specified lifetimes. This affects the following operations:
+ * * `PutItem` is intercepted in [modifyBeforeInvocation] to update the low-level request item with the calculated
+ *   field values
+ * * `UpdateItem` is intercepted in [modifyBeforeSerialization] to augment the high-level request's update expression
+ * * `BatchWriteItem` is intercepted in [modifyBeforeInvocation] to update the items of each low-level put request
+ * * `TransactWriteItems` is intercepted in both [modifyBeforeSerialization] (to augment the update expression of each
+ *   `Update` action) and [modifyBeforeInvocation] (to update the items of each low-level `Put` action)
+ *
+ * TTL fields are read from the schema associated with each operation. For the single-item operations this is the
+ * operation's [serialize schema][HReqContext.serializeSchema]; for the multi-table operations (`BatchWriteItem` and
+ * `TransactWriteItems`) the operation-level schema is a placeholder, so the per-table schemas carried by the request
+ * are used instead.
  */
 public class TtlInterceptor(private val clock: Clock = Clock.System) : InterceptorAny {
-    override fun modifyBeforeInvocation(ctx: LReqContext<Any, ItemSchema<Any>, Any, Any>): Any {
-        val ttlFields = ctx.serializeSchema.attributes.getOrNull(SchemaAttributes.TtlFields) ?: return ctx.lowLevelRequest
-
-        return when (val originalReq = ctx.lowLevelRequest) {
-            is LowLevelPutItemRequest -> handlePutItem(originalReq, ttlFields)
-            else -> originalReq
+    override fun modifyBeforeInvocation(ctx: LReqContext<Any, ItemSchema<Any>, Any, Any>): Any = when (val originalReq = ctx.lowLevelRequest) {
+        is LowLevelPutItemRequest -> {
+            val ttlFields = ctx.serializeSchema.attributes.getOrNull(SchemaAttributes.TtlFields)
+                ?: return originalReq
+            handlePutItem(originalReq, ttlFields)
         }
+
+        is LowLevelBatchWriteItemRequest ->
+            handleBatchWriteItem(originalReq, ctx.highLevelRequest as BatchWriteItemRequest)
+
+        is LowLevelTransactWriteItemsRequest ->
+            handleTransactWriteItems(originalReq, ctx.highLevelRequest as TransactWriteItemsRequest)
+
+        else -> originalReq
     }
 
-    override fun modifyBeforeSerialization(ctx: HReqContext<Any, ItemSchema<Any>, Any>): SerializeInput<Any, ItemSchema<Any>, Any> {
-        val ttlFields = ctx.serializeSchema.attributes.getOrNull(SchemaAttributes.TtlFields) ?: return ctx
-
-        val updatedReq = when (val originalReq = ctx.highLevelRequest) {
-            is UpdateItemRequest -> handleUpdateItem(originalReq, ttlFields)
-            else -> return ctx
+    override fun modifyBeforeSerialization(ctx: HReqContext<Any, ItemSchema<Any>, Any>): SerializeInput<Any, ItemSchema<Any>, Any> = when (val originalReq = ctx.highLevelRequest) {
+        is UpdateItemRequest -> {
+            val ttlFields = ctx.serializeSchema.attributes.getOrNull(SchemaAttributes.TtlFields)
+                ?: return ctx
+            SerializeInput(handleUpdateItem(originalReq, ttlFields), ctx.serializeSchema)
         }
 
-        return SerializeInput(updatedReq, ctx.serializeSchema)
+        is TransactWriteItemsRequest -> {
+            if (originalReq.tables.none { it.itemSchema.ttlFields.isNotEmpty() }) return ctx
+            SerializeInput(handleTransactWriteItemsUpdates(originalReq), ctx.serializeSchema)
+        }
+
+        else -> ctx
     }
 
     private fun handlePutItem(request: LowLevelPutItemRequest, ttlFields: Map<String, Long>): LowLevelPutItemRequest {
-        val item = request.item?.toMutableMap() ?: return request
+        val item = request.item ?: return request
+        return request.copy { this.item = setTtls(item, ttlFields) }
+    }
 
-        ttlFields.forEach { (fieldName, lifetime) ->
-            val ttlValue = av(clock.now().epochSeconds + lifetime)
-            item[fieldName] = ttlValue
+    private fun handleBatchWriteItem(
+        request: LowLevelBatchWriteItemRequest,
+        highLevelRequest: BatchWriteItemRequest,
+    ): LowLevelBatchWriteItemRequest {
+        val ttlFieldsByTable = highLevelRequest.tables
+            .associate { it.tableName to it.itemSchema.ttlFields }
+            .filterValues { it.isNotEmpty() }
+
+        if (ttlFieldsByTable.isEmpty()) return request
+
+        return request.copy {
+            requestItems = request.requestItems?.mapValues { (tableName, writeRequests) ->
+                val ttlFields = ttlFieldsByTable[tableName] ?: return@mapValues writeRequests
+                writeRequests.map { writeRequest ->
+                    val putRequest = writeRequest.putRequest ?: return@map writeRequest // leave delete requests untouched
+                    writeRequest.copy {
+                        this.putRequest = putRequest.copy { item = setTtls(putRequest.item, ttlFields) }
+                    }
+                }
+            }
         }
+    }
 
-        return request.copy { this.item = item }
+    private fun handleTransactWriteItems(
+        request: LowLevelTransactWriteItemsRequest,
+        highLevelRequest: TransactWriteItemsRequest,
+    ): LowLevelTransactWriteItemsRequest {
+        val ttlFieldsByTable = highLevelRequest.tables
+            .associate { it.tableName to it.itemSchema.ttlFields }
+            .filterValues { it.isNotEmpty() }
+
+        if (ttlFieldsByTable.isEmpty()) return request
+
+        return request.copy {
+            transactItems = request.transactItems?.map { transactItem ->
+                val put = transactItem.put ?: return@map transactItem // only `Put` actions; `Update` is handled high-level
+                val ttlFields = ttlFieldsByTable[put.tableName] ?: return@map transactItem
+                transactItem.copy { this.put = put.copy { item = setTtls(put.item, ttlFields) } }
+            }
+        }
     }
 
     private fun handleUpdateItem(
         request: UpdateItemRequest,
         ttlFields: Map<String, Long>,
     ): UpdateItemRequest = when (request) {
-        is UpdateItemRequest.PartitionKey<*> -> request.toBuilder().apply {
-            update {
-                set {
-                    ttlFields.forEach { (fieldName, lifetime) ->
-                        attr[fieldName] = clock.now().epochSeconds + lifetime
-                    }
-                }
-            }
-        }.build()
+        is UpdateItemRequest.PartitionKey<*> ->
+            request.toBuilder().apply { update = augmentUpdateExpr(update, ttlFields) }.build()
 
-        is UpdateItemRequest.CompositeKey<*, *> -> request.toBuilder().apply {
-            update {
-                set {
-                    ttlFields.forEach { (fieldName, lifetime) ->
-                        attr[fieldName] = clock.now().epochSeconds + lifetime
-                    }
+        is UpdateItemRequest.CompositeKey<*, *> ->
+            request.toBuilder().apply { update = augmentUpdateExpr(update, ttlFields) }.build()
+    }
+
+    private fun handleTransactWriteItemsUpdates(request: TransactWriteItemsRequest): TransactWriteItemsRequest {
+        val newTables = request.tables.map { table ->
+            val ttlFields = table.itemSchema.ttlFields
+            if (ttlFields.isEmpty()) table else augmentTableUpdates(table, ttlFields)
+        }
+        return request.copy { tables = newTables }
+    }
+
+    private fun augmentTableUpdates(
+        table: TransactWriteItemsRequestTable<*>,
+        ttlFields: Map<String, Long>,
+    ): TransactWriteItemsRequestTable<*> = when (table) {
+        is TransactWriteItemsRequestTable.PartitionKey<*, *> -> augmentPartitionKeyTable(table, ttlFields)
+        is TransactWriteItemsRequestTable.CompositeKey<*, *, *> -> augmentCompositeKeyTable(table, ttlFields)
+    }
+
+    private fun <T, PK : KeyType> augmentPartitionKeyTable(
+        table: TransactWriteItemsRequestTable.PartitionKey<T, PK>,
+        ttlFields: Map<String, Long>,
+    ): TransactWriteItemsRequestTable.PartitionKey<T, PK> = if (table.updates.isEmpty()) {
+        table
+    } else {
+        TransactWriteItemsRequestTable(
+            conditionChecks = table.conditionChecks,
+            deletes = table.deletes,
+            puts = table.puts,
+            schema = table.schema,
+            tableName = table.tableName,
+            updates = table.updates.map { it.augment(ttlFields) },
+        )
+    }
+
+    private fun <T, PK : KeyType, SK : KeyType> augmentCompositeKeyTable(
+        table: TransactWriteItemsRequestTable.CompositeKey<T, PK, SK>,
+        ttlFields: Map<String, Long>,
+    ): TransactWriteItemsRequestTable.CompositeKey<T, PK, SK> = if (table.updates.isEmpty()) {
+        table
+    } else {
+        TransactWriteItemsRequestTable(
+            conditionChecks = table.conditionChecks,
+            deletes = table.deletes,
+            puts = table.puts,
+            schema = table.schema,
+            tableName = table.tableName,
+            updates = table.updates.map { it.augment(ttlFields) },
+        )
+    }
+
+    private fun <E> TransactWriteItemsAction.Update<E>.augment(
+        ttlFields: Map<String, Long>,
+    ): TransactWriteItemsAction.Update<E> = TransactWriteItemsAction.Update(
+        condition = condition,
+        entity = entity,
+        returnValuesOnConditionCheckFailure = returnValuesOnConditionCheckFailure,
+        update = augmentUpdateExpr(update, ttlFields),
+    )
+
+    /**
+     * Sets each TTL field in [item] to the current time plus its configured lifetime.
+     */
+    private fun setTtls(
+        item: Map<String, AttributeValue>,
+        ttlFields: Map<String, Long>,
+    ): Map<String, AttributeValue> {
+        val now = clock.now().epochSeconds
+        val newItem = item.toMutableMap()
+        ttlFields.forEach { (fieldName, lifetime) ->
+            newItem[fieldName] = av(now + lifetime)
+        }
+        return newItem
+    }
+
+    /**
+     * Returns a new [UpdateExpr] which augments [existing] with a `SET` clause setting each TTL field to the current
+     * time plus its configured lifetime.
+     */
+    private fun augmentUpdateExpr(existing: UpdateExpr?, ttlFields: Map<String, Long>): UpdateExpr {
+        val now = clock.now().epochSeconds
+        return UpdateDslImpl(existing).apply {
+            set {
+                ttlFields.forEach { (fieldName, lifetime) ->
+                    attr[fieldName] = now + lifetime
                 }
             }
-        }.build()
+        }.toExpression()
     }
 }
+
+private val ItemSchema<*>.ttlFields: Map<String, Long>
+    get() = attributes.getOrNull(SchemaAttributes.TtlFields).orEmpty()
+
+private val BatchWriteItemRequestTable<*>.itemSchema: ItemSchema<*>
+    get() = when (this) {
+        is BatchWriteItemRequestTable.PartitionKey<*, *> -> schema
+        is BatchWriteItemRequestTable.CompositeKey<*, *, *> -> schema
+    }
+
+private val TransactWriteItemsRequestTable<*>.itemSchema: ItemSchema<*>
+    get() = when (this) {
+        is TransactWriteItemsRequestTable.PartitionKey<*, *> -> schema
+        is TransactWriteItemsRequestTable.CompositeKey<*, *, *> -> schema
+    }

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/internal/DynamoDbMapperImpl.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/internal/DynamoDbMapperImpl.kt
@@ -63,7 +63,7 @@ internal data class MapperConfigImpl(
 }
 
 internal class MapperConfigBuilderImpl : DynamoDbMapper.Config.Builder {
-    override var interceptors = mutableListOf<InterceptorAny>(
+    override var interceptors = mutableListOf(
         // Default interceptors
         TtlInterceptor(),
         CounterInterceptor(),

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/ItemSchema.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/ItemSchema.kt
@@ -8,6 +8,7 @@ import aws.sdk.kotlin.hll.dynamodbmapper.items.internal.ItemSchemaCompositeKeyIm
 import aws.sdk.kotlin.hll.dynamodbmapper.items.internal.ItemSchemaPartitionKeyImpl
 import aws.sdk.kotlin.hll.dynamodbmapper.items.internal.attrs
 import aws.smithy.kotlin.runtime.collections.Attributes
+import aws.smithy.kotlin.runtime.collections.emptyAttributes
 
 /**
  * Defines a schema for handling objects of type [T], including an [ItemConverter] for converting between objects and
@@ -73,9 +74,15 @@ public sealed interface ItemSchema<T> {
  * @param PK The type of the partition key property, either [KeyType] or one of its specific derivations
  * @param converter The [ItemConverter] used to convert between objects and items
  * @param partitionKey The [KeySpec] for the partition key
+ * @param attributes An optional [Attributes] instance which may include additional metadata about the schema. If not
+ * provided, defaults to [emptyAttributes].
  */
 @Suppress("FunctionName")
-public fun <T, PK : KeyType> ItemSchema(converter: ItemConverter<T>, partitionKey: KeySpec<PK>): ItemSchema.PartitionKey<T, PK> = ItemSchemaPartitionKeyImpl(converter, partitionKey)
+public fun <T, PK : KeyType> ItemSchema(
+    converter: ItemConverter<T>,
+    partitionKey: KeySpec<PK>,
+    attributes: Attributes = emptyAttributes(),
+): ItemSchema.PartitionKey<T, PK> = ItemSchemaPartitionKeyImpl(converter, partitionKey, attributes)
 
 /**
  * Create a new item schema with a primary key consisting of a single partition key.
@@ -85,21 +92,29 @@ public fun <T, PK : KeyType> ItemSchema(converter: ItemConverter<T>, partitionKe
  * @param converter The [ItemConverter] used to convert between objects and items
  * @param partitionKey The [KeySpec] for the partition key
  * @param sortKey The [KeySpec] for the sort key
+ * @param attributes An optional [Attributes] instance which may include additional metadata about the schema. If not
+ * provided, defaults to [emptyAttributes].
  */
 @Suppress("FunctionName")
 public fun <T, PK : KeyType, SK : KeyType> ItemSchema(
     converter: ItemConverter<T>,
     partitionKey: KeySpec<PK>,
     sortKey: KeySpec<SK>,
-): ItemSchema.CompositeKey<T, PK, SK> = ItemSchemaCompositeKeyImpl(converter, partitionKey, sortKey)
+    attributes: Attributes = emptyAttributes(),
+): ItemSchema.CompositeKey<T, PK, SK> = ItemSchemaCompositeKeyImpl(converter, partitionKey, sortKey, attributes)
 
 /**
  * Associate this [ItemConverter] with a [KeySpec] for a partition key to form a complete [ItemSchema]
  * @param T The type of objects described by this schema
  * @param PK The type of the partition key property, either [KeyType] or one of its specific derivations
  * @param partitionKey The [KeySpec] that describes the partition key
+ * @param attributes An optional [Attributes] instance which may include additional metadata about the schema. If not
+ * provided, defaults to [emptyAttributes].
  */
-public fun <T, PK : KeyType> ItemConverter<T>.withKeySpec(partitionKey: KeySpec<PK>): ItemSchema.PartitionKey<T, PK> = ItemSchema(this, partitionKey)
+public fun <T, PK : KeyType> ItemConverter<T>.withKeySpec(
+    partitionKey: KeySpec<PK>,
+    attributes: Attributes = emptyAttributes(),
+): ItemSchema.PartitionKey<T, PK> = ItemSchema(this, partitionKey, attributes)
 
 /**
  * Associate this [ItemConverter] with [KeySpec] instances for a composite key to form a complete [ItemSchema]
@@ -108,8 +123,11 @@ public fun <T, PK : KeyType> ItemConverter<T>.withKeySpec(partitionKey: KeySpec<
  * @param SK The type of the sort key property, either [KeyType] or one of its specific derivations
  * @param partitionKey The [KeySpec] that describes the partition key
  * @param sortKey The [KeySpec] that describes the sort key
+ * @param attributes An optional [Attributes] instance which may include additional metadata about the schema. If not
+ * provided, defaults to [emptyAttributes].
  */
 public fun <T, PK : KeyType, SK : KeyType> ItemConverter<T>.withKeySpec(
     partitionKey: KeySpec<PK>,
     sortKey: KeySpec<SK>,
-): ItemSchema.CompositeKey<T, PK, SK> = ItemSchema(this, partitionKey, sortKey)
+    attributes: Attributes = emptyAttributes(),
+): ItemSchema.CompositeKey<T, PK, SK> = ItemSchema(this, partitionKey, sortKey, attributes)

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/model/SchemaAttributes.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/model/SchemaAttributes.kt
@@ -13,7 +13,7 @@ public object SchemaAttributes {
     /**
      * Set of TTL fields, each containing field name and lifetime in seconds
      */
-    public val TtlFields: AttributeKey<Set<Pair<String, Long>>> = AttributeKey("aws.sdk.kotlin.hll.dynamodbmapper#TtlFields")
+    public val TtlFields: AttributeKey<Map<String, Long>> = AttributeKey("aws.sdk.kotlin.hll.dynamodbmapper#TtlFields")
 
     /**
      * Set of field names annotated with [DynamoDbCounter]

--- a/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/expressions/AttributePathTest.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/expressions/AttributePathTest.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.sdk.kotlin.hll.dynamodbmapper.expressions
+
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.AttrImpl
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AttributePathTest {
+    @Test
+    fun testToString() {
+        val testCases = mapOf(
+            AttrImpl["foo"] to "foo",
+            AttrImpl["foo"]["bar"] to "foo.bar",
+            AttrImpl["foo"][1] to "foo[1]",
+            AttrImpl["foo"][1]["bar"] to "foo[1].bar",
+        )
+        testCases.entries.forEach { (attr, expected) -> assertEquals(expected, attr.toString()) }
+    }
+}

--- a/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/BatchWriteItemCounterInterceptorTest.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/BatchWriteItemCounterInterceptorTest.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.sdk.kotlin.hll.dynamodbmapper.interceptors
+
+import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
+import aws.sdk.kotlin.hll.dynamodbmapper.items.KeySpec
+import aws.sdk.kotlin.hll.dynamodbmapper.model.SchemaAttributes
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.BatchWriteItemRequest
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.BatchWriteItemRequestTable
+import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.LReqContext
+import aws.sdk.kotlin.hll.dynamodbmapper.testutils.testConverter
+import aws.sdk.kotlin.hll.dynamodbmapper.testutils.testMapperContext
+import aws.sdk.kotlin.hll.dynamodbmapper.testutils.testSchema
+import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
+import aws.sdk.kotlin.services.dynamodb.model.WriteRequest
+import aws.smithy.kotlin.runtime.collections.attributesOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import aws.sdk.kotlin.services.dynamodb.model.BatchWriteItemRequest as LowLevelBatchWriteItemRequest
+
+class BatchWriteItemCounterInterceptorTest {
+    @Test
+    fun testIncrementsPutItemsOnly() {
+        val interceptor = CounterInterceptor()
+        val schema = ItemSchema(
+            testConverter(),
+            KeySpec.string("id"),
+            attributesOf { SchemaAttributes.CounterFields to setOf("counter1") },
+        )
+
+        val highLevelRequest = BatchWriteItemRequest {
+            tables = listOf(BatchWriteItemRequestTable(emptyList(), "table1", emptyList(), schema))
+        }
+
+        val lowLevelRequest = LowLevelBatchWriteItemRequest {
+            requestItems = mapOf(
+                "table1" to listOf(
+                    WriteRequest {
+                        putRequest { item = mapOf("id" to AttributeValue.S("a"), "counter1" to AttributeValue.N("5")) }
+                    },
+                    WriteRequest {
+                        putRequest { item = mapOf("id" to AttributeValue.S("b")) } // missing counter -> defaults to 0
+                    },
+                    WriteRequest {
+                        deleteRequest { key = mapOf("id" to AttributeValue.S("c")) } // must be left untouched
+                    },
+                ),
+            )
+        }
+
+        val result = interceptor.modifyBeforeInvocation(
+            createContext(highLevelRequest, lowLevelRequest),
+        ) as LowLevelBatchWriteItemRequest
+
+        val writes = result.requestItems!!["table1"]!!
+        assertEquals("6", writes[0].putRequest!!.item["counter1"]!!.asN())
+        assertEquals("1", writes[1].putRequest!!.item["counter1"]!!.asN())
+        assertNull(writes[2].putRequest)
+        assertEquals(mapOf("id" to AttributeValue.S("c")), writes[2].deleteRequest!!.key)
+    }
+
+    @Test
+    fun testRoutesCounterFieldsByTable() {
+        val interceptor = CounterInterceptor()
+        val schemaWithCounter = ItemSchema(
+            testConverter(),
+            KeySpec.string("id"),
+            attributesOf { SchemaAttributes.CounterFields to setOf("counter1") },
+        )
+        val schemaWithoutCounter = ItemSchema(testConverter(), KeySpec.string("id"))
+
+        val highLevelRequest = BatchWriteItemRequest {
+            tables = listOf(
+                BatchWriteItemRequestTable(emptyList(), "withCounter", emptyList(), schemaWithCounter),
+                BatchWriteItemRequestTable(emptyList(), "withoutCounter", emptyList(), schemaWithoutCounter),
+            )
+        }
+
+        val lowLevelRequest = LowLevelBatchWriteItemRequest {
+            requestItems = mapOf(
+                "withCounter" to listOf(WriteRequest { putRequest { item = mapOf("counter1" to AttributeValue.N("5")) } }),
+                "withoutCounter" to listOf(WriteRequest { putRequest { item = mapOf("counter1" to AttributeValue.N("5")) } }),
+            )
+        }
+
+        val result = interceptor.modifyBeforeInvocation(
+            createContext(highLevelRequest, lowLevelRequest),
+        ) as LowLevelBatchWriteItemRequest
+
+        assertEquals("6", result.requestItems!!["withCounter"]!![0].putRequest!!.item["counter1"]!!.asN())
+        assertEquals("5", result.requestItems!!["withoutCounter"]!![0].putRequest!!.item["counter1"]!!.asN())
+    }
+
+    @Test
+    fun testNoCounterFieldsIsNoOp() {
+        val interceptor = CounterInterceptor()
+        val schema = ItemSchema(testConverter(), KeySpec.string("id"))
+
+        val highLevelRequest = BatchWriteItemRequest {
+            tables = listOf(BatchWriteItemRequestTable(emptyList(), "table1", emptyList(), schema))
+        }
+
+        val lowLevelRequest = LowLevelBatchWriteItemRequest {
+            requestItems = mapOf("table1" to listOf(WriteRequest { putRequest { item = mapOf("id" to AttributeValue.S("a")) } }))
+        }
+
+        val result = interceptor.modifyBeforeInvocation(createContext(highLevelRequest, lowLevelRequest))
+        assertSame(lowLevelRequest, result)
+    }
+}
+
+private fun createContext(
+    highLevelRequest: Any,
+    lowLevelRequest: Any,
+): LReqContext<Any, ItemSchema<Any>, Any, Any> = LReqContext(highLevelRequest, testSchema { }, testMapperContext(), lowLevelRequest)

--- a/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/BatchWriteItemTtlInterceptorTest.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/BatchWriteItemTtlInterceptorTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.sdk.kotlin.hll.dynamodbmapper.interceptors
+
+import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
+import aws.sdk.kotlin.hll.dynamodbmapper.items.KeySpec
+import aws.sdk.kotlin.hll.dynamodbmapper.model.SchemaAttributes
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.BatchWriteItemRequest
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.BatchWriteItemRequestTable
+import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.LReqContext
+import aws.sdk.kotlin.hll.dynamodbmapper.testutils.testConverter
+import aws.sdk.kotlin.hll.dynamodbmapper.testutils.testMapperContext
+import aws.sdk.kotlin.hll.dynamodbmapper.testutils.testSchema
+import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
+import aws.sdk.kotlin.services.dynamodb.model.WriteRequest
+import aws.smithy.kotlin.runtime.collections.attributesOf
+import aws.smithy.kotlin.runtime.time.Instant
+import aws.smithy.kotlin.runtime.time.ManualClock
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.time.Duration.Companion.hours
+import aws.sdk.kotlin.services.dynamodb.model.BatchWriteItemRequest as LowLevelBatchWriteItemRequest
+
+class BatchWriteItemTtlInterceptorTest {
+    @Test
+    fun testSetsTtlOnPutItemsOnly() {
+        val clock = ManualClock(Instant.fromEpochSeconds(0))
+        val interceptor = TtlInterceptor(clock)
+        val ttlFields = mapOf("expiresAt" to 1.hours.inWholeSeconds)
+        val schema = ItemSchema(
+            testConverter(),
+            KeySpec.string("id"),
+            attributesOf { SchemaAttributes.TtlFields to ttlFields },
+        )
+
+        val highLevelRequest = BatchWriteItemRequest {
+            tables = listOf(BatchWriteItemRequestTable(emptyList(), "table1", emptyList(), schema))
+        }
+
+        val lowLevelRequest = LowLevelBatchWriteItemRequest {
+            requestItems = mapOf(
+                "table1" to listOf(
+                    WriteRequest { putRequest { item = mapOf("id" to AttributeValue.S("a")) } },
+                    WriteRequest { deleteRequest { key = mapOf("id" to AttributeValue.S("b")) } }, // untouched
+                ),
+            )
+        }
+
+        val result = interceptor.modifyBeforeInvocation(
+            createContext(highLevelRequest, lowLevelRequest),
+        ) as LowLevelBatchWriteItemRequest
+
+        val writes = result.requestItems!!["table1"]!!
+        assertEquals(AttributeValue.N("3600"), writes[0].putRequest!!.item["expiresAt"])
+        assertNull(writes[1].putRequest)
+        assertNull(writes[1].deleteRequest!!.key["expiresAt"])
+    }
+
+    @Test
+    fun testRoutesTtlFieldsByTable() {
+        val clock = ManualClock(Instant.fromEpochSeconds(0))
+        val interceptor = TtlInterceptor(clock)
+        val ttlFields = mapOf("expiresAt" to 1.hours.inWholeSeconds)
+        val schemaWithTtl = ItemSchema(
+            testConverter(),
+            KeySpec.string("id"),
+            attributesOf { SchemaAttributes.TtlFields to ttlFields },
+        )
+        val schemaWithoutTtl = ItemSchema(testConverter(), KeySpec.string("id"))
+
+        val highLevelRequest = BatchWriteItemRequest {
+            tables = listOf(
+                BatchWriteItemRequestTable(emptyList(), "withTtl", emptyList(), schemaWithTtl),
+                BatchWriteItemRequestTable(emptyList(), "withoutTtl", emptyList(), schemaWithoutTtl),
+            )
+        }
+
+        val lowLevelRequest = LowLevelBatchWriteItemRequest {
+            requestItems = mapOf(
+                "withTtl" to listOf(WriteRequest { putRequest { item = mapOf("id" to AttributeValue.S("a")) } }),
+                "withoutTtl" to listOf(WriteRequest { putRequest { item = mapOf("id" to AttributeValue.S("b")) } }),
+            )
+        }
+
+        val result = interceptor.modifyBeforeInvocation(
+            createContext(highLevelRequest, lowLevelRequest),
+        ) as LowLevelBatchWriteItemRequest
+
+        assertEquals(AttributeValue.N("3600"), result.requestItems!!["withTtl"]!![0].putRequest!!.item["expiresAt"])
+        assertNull(result.requestItems!!["withoutTtl"]!![0].putRequest!!.item["expiresAt"])
+    }
+
+    @Test
+    fun testNoTtlFieldsIsNoOp() {
+        val interceptor = TtlInterceptor(ManualClock(Instant.fromEpochSeconds(0)))
+        val schema = ItemSchema(testConverter(), KeySpec.string("id"))
+
+        val highLevelRequest = BatchWriteItemRequest {
+            tables = listOf(BatchWriteItemRequestTable(emptyList(), "table1", emptyList(), schema))
+        }
+
+        val lowLevelRequest = LowLevelBatchWriteItemRequest {
+            requestItems = mapOf("table1" to listOf(WriteRequest { putRequest { item = mapOf("id" to AttributeValue.S("a")) } }))
+        }
+
+        val result = interceptor.modifyBeforeInvocation(createContext(highLevelRequest, lowLevelRequest))
+        assertSame(lowLevelRequest, result)
+    }
+}
+
+private fun createContext(
+    highLevelRequest: Any,
+    lowLevelRequest: Any,
+): LReqContext<Any, ItemSchema<Any>, Any, Any> = LReqContext(highLevelRequest, testSchema { }, testMapperContext(), lowLevelRequest)

--- a/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/PutItemCounterInterceptorTest.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/PutItemCounterInterceptorTest.kt
@@ -4,25 +4,19 @@
  */
 package aws.sdk.kotlin.hll.dynamodbmapper.interceptors
 
-import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemConverter
 import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
-import aws.sdk.kotlin.hll.dynamodbmapper.items.KeySpec
-import aws.sdk.kotlin.hll.dynamodbmapper.items.internal.ItemSchemaPartitionKeyImpl
-import aws.sdk.kotlin.hll.dynamodbmapper.model.PersistenceSpec
 import aws.sdk.kotlin.hll.dynamodbmapper.model.SchemaAttributes
-import aws.sdk.kotlin.hll.dynamodbmapper.model.buildItem
 import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.LReqContext
-import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.MapperContext
-import aws.sdk.kotlin.hll.mapping.core.converters.ConverterImpl
+import aws.sdk.kotlin.hll.dynamodbmapper.testutils.testMapperContext
+import aws.sdk.kotlin.hll.dynamodbmapper.testutils.testSchema
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
 import aws.sdk.kotlin.services.dynamodb.model.PutItemRequest
-import aws.smithy.kotlin.runtime.collections.attributesOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertSame
 
-class CounterInterceptorTest {
+class PutItemCounterInterceptorTest {
     @Test
     fun testCounterInterceptorIncrementsFields() {
         val counterFields = setOf("counter1", "counter2")
@@ -70,7 +64,7 @@ class CounterInterceptorTest {
             tableName = "test-table"
             item = mapOf("id" to AttributeValue.S("test"))
         }
-        val ctx = createContext(request, null)
+        val ctx = createContext(request)
 
         val result = interceptor.modifyBeforeInvocation(ctx)
         assertSame(request, result)
@@ -78,9 +72,10 @@ class CounterInterceptorTest {
 
     @Test
     fun testCounterInterceptorNonPutItemRequest() {
+        val counterFields = setOf("counter1")
         val interceptor = CounterInterceptor()
         val otherRequest = "not a put item request"
-        val ctx = createContext(otherRequest, setOf("counter"))
+        val ctx = createContext(otherRequest, counterFields)
 
         val result = interceptor.modifyBeforeInvocation(ctx)
         assertSame(otherRequest, result)
@@ -105,30 +100,13 @@ class CounterInterceptorTest {
             interceptor.modifyBeforeInvocation(ctx)
         }
     }
+}
 
-    private fun createContext(
-        lowLevelRequest: Any,
-        counterFields: Set<String>?,
-    ): LReqContext<Any, ItemSchema<Any>, Any, Any> {
-        val attributes = attributesOf {
-            counterFields?.let { SchemaAttributes.CounterFields to it }
-        }
-
-        val converter: ItemConverter<Any> = ConverterImpl(convertRight = { buildItem { } }, convertLeft = { "" })
-
-        val schema = ItemSchemaPartitionKeyImpl(
-            converter = converter,
-            partitionKey = KeySpec.string("id"),
-            attributes = attributes,
-        )
-
-        val mapperContext = object : MapperContext<Any> {
-            override val persistenceSpec: PersistenceSpec<Any>
-                get() = error("Not needed for test")
-            override val operation: String
-                get() = error("Not needed for test")
-        }
-
-        return LReqContext("", schema, mapperContext, lowLevelRequest)
-    }
+private fun createContext(
+    lowLevelRequest: Any,
+    counterFields: Set<String>? = null,
+): LReqContext<Any, ItemSchema<Any>, Any, Any> {
+    val schema = testSchema { counterFields?.let { SchemaAttributes.CounterFields to it } }
+    val mapperContext = testMapperContext()
+    return LReqContext("", schema, mapperContext, lowLevelRequest)
 }

--- a/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/PutItemTtlInterceptorTest.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/PutItemTtlInterceptorTest.kt
@@ -4,19 +4,13 @@
  */
 package aws.sdk.kotlin.hll.dynamodbmapper.interceptors
 
-import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemConverter
 import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
-import aws.sdk.kotlin.hll.dynamodbmapper.items.KeySpec
-import aws.sdk.kotlin.hll.dynamodbmapper.items.internal.ItemSchemaPartitionKeyImpl
-import aws.sdk.kotlin.hll.dynamodbmapper.model.PersistenceSpec
 import aws.sdk.kotlin.hll.dynamodbmapper.model.SchemaAttributes
-import aws.sdk.kotlin.hll.dynamodbmapper.model.buildItem
 import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.LReqContext
-import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.MapperContext
-import aws.sdk.kotlin.hll.mapping.core.converters.ConverterImpl
+import aws.sdk.kotlin.hll.dynamodbmapper.testutils.testMapperContext
+import aws.sdk.kotlin.hll.dynamodbmapper.testutils.testSchema
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
 import aws.sdk.kotlin.services.dynamodb.model.PutItemRequest
-import aws.smithy.kotlin.runtime.collections.attributesOf
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.time.ManualClock
 import kotlin.test.Test
@@ -24,19 +18,19 @@ import kotlin.test.assertEquals
 import kotlin.test.assertSame
 import kotlin.time.Duration.Companion.hours
 
-class TtlInterceptorTest {
+class PutItemTtlInterceptorTest {
     @Test
     fun testPutItemWithSingleTtlField() {
         val testClock = ManualClock(Instant.fromEpochSeconds(0))
         val interceptor = TtlInterceptor(testClock)
-        val ttlFields = setOf("expiresAt" to 1.hours.inWholeSeconds)
+        val ttlFields = mapOf("expiresAt" to 1.hours.inWholeSeconds)
 
         val request = PutItemRequest {
             tableName = "test-table"
             item = mapOf("id" to AttributeValue.S("test-id"))
         }
 
-        val context = createTestContext(request, ttlFields)
+        val context = createContext(request, ttlFields)
         val result1 = interceptor.modifyBeforeInvocation(context) as PutItemRequest
         assertEquals(AttributeValue.N("3600"), result1.item?.get("expiresAt"))
 
@@ -50,7 +44,7 @@ class TtlInterceptorTest {
     fun testPutItemWithMultipleTtlFields() {
         val testClock = ManualClock(Instant.fromEpochSeconds(0))
         val interceptor = TtlInterceptor(testClock)
-        val ttlFields = setOf(
+        val ttlFields = mapOf(
             "expiresAt" to 1.hours.inWholeSeconds,
             "actuallyExpiresAt" to 2.hours.inWholeSeconds,
         )
@@ -60,7 +54,7 @@ class TtlInterceptorTest {
             item = mapOf("id" to AttributeValue.S("test-id"))
         }
 
-        val context = createTestContext(request, ttlFields)
+        val context = createContext(request, ttlFields)
         val result = interceptor.modifyBeforeInvocation(context) as PutItemRequest
 
         assertEquals(AttributeValue.N("3600"), result.item?.get("expiresAt"))
@@ -76,7 +70,7 @@ class TtlInterceptorTest {
             item = mapOf("id" to AttributeValue.S("test-id"))
         }
 
-        val context = createTestContext(request, emptySet())
+        val context = createContext(request)
         val result = interceptor.modifyBeforeInvocation(context)
 
         assertSame(request, result)
@@ -86,9 +80,9 @@ class TtlInterceptorTest {
     fun testNonPutItemRequest() {
         val interceptor = TtlInterceptor()
         val otherRequest = "not-a-put-request"
-        val ttlFields = setOf("expiresAt" to 3600L)
+        val ttlFields = mapOf("expiresAt" to 3600L)
 
-        val context = createTestContext(otherRequest, ttlFields)
+        val context = createContext(otherRequest, ttlFields)
         val result = interceptor.modifyBeforeInvocation(context)
 
         assertSame(otherRequest, result)
@@ -97,44 +91,25 @@ class TtlInterceptorTest {
     @Test
     fun testPutItemWithEmptyItem() {
         val interceptor = TtlInterceptor()
-        val ttlFields = setOf("expiresAt" to 3600L)
+        val ttlFields = mapOf("expiresAt" to 3600L)
 
         val request = PutItemRequest {
             tableName = "test-table"
             item = null
         }
 
-        val context = createTestContext(request, ttlFields)
+        val context = createContext(request, ttlFields)
         val result = interceptor.modifyBeforeInvocation(context)
 
         assertSame(request, result)
     }
+}
 
-    private fun createTestContext(
-        lowLevelRequest: Any,
-        ttlFields: Set<Pair<String, Long>>,
-    ): LReqContext<Any, ItemSchema<Any>, Any, Any> {
-        val attributes = attributesOf {
-            if (ttlFields.isNotEmpty()) {
-                SchemaAttributes.TtlFields to ttlFields
-            }
-        }
-
-        val converter: ItemConverter<Any> = ConverterImpl(convertRight = { buildItem { } }, convertLeft = { "" })
-
-        val schema = ItemSchemaPartitionKeyImpl(
-            converter = converter,
-            partitionKey = KeySpec.string("id"),
-            attributes = attributes,
-        )
-
-        val mapperContext = object : MapperContext<Any> {
-            override val persistenceSpec: PersistenceSpec<Any>
-                get() = error("Not needed for test")
-            override val operation: String
-                get() = error("Not needed for test")
-        }
-
-        return LReqContext("", schema, mapperContext, lowLevelRequest)
-    }
+private fun createContext(
+    lowLevelRequest: Any,
+    ttlFields: Map<String, Long>? = null,
+): LReqContext<Any, ItemSchema<Any>, Any, Any> {
+    val schema = testSchema { ttlFields?.let { SchemaAttributes.TtlFields to it } }
+    val mapperContext = testMapperContext()
+    return LReqContext("", schema, mapperContext, lowLevelRequest)
 }

--- a/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/TransactWriteItemsCounterInterceptorTest.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/TransactWriteItemsCounterInterceptorTest.kt
@@ -1,0 +1,209 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.sdk.kotlin.hll.dynamodbmapper.interceptors
+
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.AdditiveExpr
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.AdditiveOperation
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.AttributePath
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.LiteralExpr
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.ScalarFunc
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.ScalarFuncExpr
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.UpdateAction
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.UpdateClauseExpr
+import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
+import aws.sdk.kotlin.hll.dynamodbmapper.items.Key
+import aws.sdk.kotlin.hll.dynamodbmapper.items.KeySpec
+import aws.sdk.kotlin.hll.dynamodbmapper.items.KeyType
+import aws.sdk.kotlin.hll.dynamodbmapper.model.SchemaAttributes
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.PartitionKey
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.TransactWriteItemsAction
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.TransactWriteItemsRequest
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.TransactWriteItemsRequestTable
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.Update
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.UpdateItemRequest
+import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.HReqContext
+import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.LReqContext
+import aws.sdk.kotlin.hll.dynamodbmapper.testutils.testConverter
+import aws.sdk.kotlin.hll.dynamodbmapper.testutils.testMapperContext
+import aws.sdk.kotlin.hll.dynamodbmapper.testutils.testSchema
+import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
+import aws.sdk.kotlin.services.dynamodb.model.TransactWriteItem
+import aws.smithy.kotlin.runtime.collections.attributesOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import aws.sdk.kotlin.services.dynamodb.model.TransactWriteItemsRequest as LowLevelTransactWriteItemsRequest
+
+class TransactWriteItemsCounterInterceptorTest {
+    private val schema = ItemSchema(
+        testConverter(),
+        KeySpec.string("id"),
+        attributesOf { SchemaAttributes.CounterFields to setOf("counter1") },
+    )
+
+    @Test
+    fun testIncrementsPutActionsOnly() {
+        val interceptor = CounterInterceptor()
+
+        val highLevelRequest = TransactWriteItemsRequest {
+            tables = listOf(
+                TransactWriteItemsRequestTable(
+                    conditionChecks = emptyList(),
+                    deletes = emptyList(),
+                    puts = emptyList(),
+                    schema = schema,
+                    tableName = "table1",
+                    updates = emptyList(),
+                ),
+            )
+        }
+
+        val lowLevelRequest = LowLevelTransactWriteItemsRequest {
+            transactItems = listOf(
+                TransactWriteItem {
+                    put {
+                        tableName = "table1"
+                        item = mapOf("id" to AttributeValue.S("a"), "counter1" to AttributeValue.N("5"))
+                    }
+                },
+                TransactWriteItem {
+                    update {
+                        tableName = "table1"
+                        key = mapOf("id" to AttributeValue.S("b"))
+                        updateExpression = "SET #foo = :bar"
+                    }
+                },
+                TransactWriteItem {
+                    delete {
+                        tableName = "table1"
+                        key = mapOf("id" to AttributeValue.S("c"))
+                    }
+                },
+            )
+        }
+
+        val result = interceptor.modifyBeforeInvocation(
+            lReqContext(highLevelRequest, lowLevelRequest),
+        ) as LowLevelTransactWriteItemsRequest
+
+        assertEquals("6", result.transactItems!![0].put!!.item["counter1"]!!.asN())
+        assertNotNull(result.transactItems!![1].update) // update action untouched at low-level phase
+        assertNotNull(result.transactItems!![2].delete)
+    }
+
+    @Test
+    fun testAugmentsUpdateActions() {
+        val interceptor = CounterInterceptor()
+
+        val seedUpdate = UpdateItemRequest.PartitionKey<KeyType.Key1<String>> {
+            update { set { attr["foo"] = "bar" } }
+        }.update!!
+
+        val highLevelRequest = TransactWriteItemsRequest {
+            tables = listOf(
+                TransactWriteItemsRequestTable(
+                    conditionChecks = emptyList(),
+                    deletes = emptyList(),
+                    puts = emptyList(),
+                    schema = schema,
+                    tableName = "table1",
+                    updates = listOf(TransactWriteItemsAction.Update(null, Key("pk"), null, seedUpdate)),
+                ),
+            )
+        }
+
+        val result = interceptor.modifyBeforeSerialization(hReqContext(highLevelRequest)).highLevelRequest as TransactWriteItemsRequest
+
+        val table = result.tables.single() as TransactWriteItemsRequestTable.PartitionKey<*, *>
+        val update = assertNotNull(table.updates.single().update)
+        val updates = update.set.updates.associateBy { it.target.toString() }
+
+        assertEquals(2, updates.size)
+        assertEquals(UpdateClauseExpr(UpdateAction.SET, AttributePath("foo"), LiteralExpr("bar")), updates["foo"])
+        assertEquals(
+            UpdateClauseExpr(
+                UpdateAction.SET,
+                AttributePath("counter1"),
+                AdditiveExpr(
+                    AdditiveOperation.ADD,
+                    ScalarFuncExpr(ScalarFunc.IF_NOT_EXISTS, AttributePath("counter1"), LiteralExpr(0)),
+                    LiteralExpr(1),
+                ),
+            ),
+            updates["counter1"],
+        )
+    }
+
+    @Test
+    fun testNoCounterFieldsLeavesUpdatesUnchanged() {
+        val interceptor = CounterInterceptor()
+        val schemaWithoutCounter = ItemSchema(testConverter(), KeySpec.string("id"))
+
+        val seedUpdate = UpdateItemRequest.PartitionKey<KeyType.Key1<String>> {
+            update { set { attr["foo"] = "bar" } }
+        }.update!!
+
+        val highLevelRequest = TransactWriteItemsRequest {
+            tables = listOf(
+                TransactWriteItemsRequestTable(
+                    conditionChecks = emptyList(),
+                    deletes = emptyList(),
+                    puts = emptyList(),
+                    schema = schemaWithoutCounter,
+                    tableName = "table1",
+                    updates = listOf(TransactWriteItemsAction.Update(null, Key("pk"), null, seedUpdate)),
+                ),
+            )
+        }
+
+        val result = interceptor.modifyBeforeSerialization(hReqContext(highLevelRequest)).highLevelRequest
+        assertEquals(highLevelRequest, result)
+
+        val table = (result as TransactWriteItemsRequest).tables.single() as TransactWriteItemsRequestTable.PartitionKey<*, *>
+        assertNull(table.updates.single().update.set.updates.associateBy { it.target.toString() }["counter1"])
+    }
+
+    @Test
+    fun testNoCounterFieldsIsNoOp() {
+        val interceptor = CounterInterceptor()
+        val schemaWithoutCounter = ItemSchema(testConverter(), KeySpec.string("id"))
+
+        val highLevelRequest = TransactWriteItemsRequest {
+            tables = listOf(
+                TransactWriteItemsRequestTable(
+                    conditionChecks = emptyList(),
+                    deletes = emptyList(),
+                    puts = emptyList(),
+                    schema = schemaWithoutCounter,
+                    tableName = "table1",
+                    updates = emptyList(),
+                ),
+            )
+        }
+
+        val lowLevelRequest = LowLevelTransactWriteItemsRequest {
+            transactItems = listOf(
+                TransactWriteItem {
+                    put {
+                        tableName = "table1"
+                        item = mapOf("id" to AttributeValue.S("a"))
+                    }
+                },
+            )
+        }
+
+        val result = interceptor.modifyBeforeInvocation(lReqContext(highLevelRequest, lowLevelRequest))
+        assertSame(lowLevelRequest, result)
+    }
+
+    private fun lReqContext(
+        highLevelRequest: Any,
+        lowLevelRequest: Any,
+    ): LReqContext<Any, ItemSchema<Any>, Any, Any> = LReqContext(highLevelRequest, testSchema { }, testMapperContext(), lowLevelRequest)
+
+    private fun hReqContext(highLevelRequest: Any): HReqContext<Any, ItemSchema<Any>, Any> = HReqContext(highLevelRequest, testSchema { }, testMapperContext())
+}

--- a/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/TransactWriteItemsCounterInterceptorTest.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/TransactWriteItemsCounterInterceptorTest.kt
@@ -120,7 +120,7 @@ class TransactWriteItemsCounterInterceptorTest {
 
         val table = result.tables.single() as TransactWriteItemsRequestTable.PartitionKey<*, *>
         val update = assertNotNull(table.updates.single().update)
-        val updates = update.set.updates.associateBy { it.target.toString() }
+        val updates = update.updates.associateBy { it.target.toString() }
 
         assertEquals(2, updates.size)
         assertEquals(UpdateClauseExpr(UpdateAction.SET, AttributePath("foo"), LiteralExpr("bar")), updates["foo"])
@@ -164,7 +164,7 @@ class TransactWriteItemsCounterInterceptorTest {
         assertEquals(highLevelRequest, result)
 
         val table = (result as TransactWriteItemsRequest).tables.single() as TransactWriteItemsRequestTable.PartitionKey<*, *>
-        assertNull(table.updates.single().update.set.updates.associateBy { it.target.toString() }["counter1"])
+        assertNull(table.updates.single().update.updates.associateBy { it.target.toString() }["counter1"])
     }
 
     @Test

--- a/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/TransactWriteItemsTtlInterceptorTest.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/TransactWriteItemsTtlInterceptorTest.kt
@@ -114,7 +114,7 @@ class TransactWriteItemsTtlInterceptorTest {
 
         val table = result.tables.single() as TransactWriteItemsRequestTable.PartitionKey<*, *>
         val update = assertNotNull(table.updates.single().update)
-        val updates = update.set.updates.associateBy { it.target.toString() }
+        val updates = update.updates.associateBy { it.target.toString() }
 
         assertEquals(2, updates.size)
         assertEquals(UpdateClauseExpr(UpdateAction.SET, AttributePath("foo"), LiteralExpr("bar")), updates["foo"])
@@ -150,7 +150,7 @@ class TransactWriteItemsTtlInterceptorTest {
         assertEquals(highLevelRequest, result)
 
         val table = (result as TransactWriteItemsRequest).tables.single() as TransactWriteItemsRequestTable.PartitionKey<*, *>
-        assertNull(table.updates.single().update.set.updates.associateBy { it.target.toString() }["expiresAt"])
+        assertNull(table.updates.single().update.updates.associateBy { it.target.toString() }["expiresAt"])
     }
 
     @Test

--- a/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/TransactWriteItemsTtlInterceptorTest.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/TransactWriteItemsTtlInterceptorTest.kt
@@ -1,0 +1,195 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.sdk.kotlin.hll.dynamodbmapper.interceptors
+
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.AttributePath
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.LiteralExpr
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.UpdateAction
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.UpdateClauseExpr
+import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
+import aws.sdk.kotlin.hll.dynamodbmapper.items.Key
+import aws.sdk.kotlin.hll.dynamodbmapper.items.KeySpec
+import aws.sdk.kotlin.hll.dynamodbmapper.items.KeyType
+import aws.sdk.kotlin.hll.dynamodbmapper.model.SchemaAttributes
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.PartitionKey
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.TransactWriteItemsAction
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.TransactWriteItemsRequest
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.TransactWriteItemsRequestTable
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.Update
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.UpdateItemRequest
+import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.HReqContext
+import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.LReqContext
+import aws.sdk.kotlin.hll.dynamodbmapper.testutils.testConverter
+import aws.sdk.kotlin.hll.dynamodbmapper.testutils.testMapperContext
+import aws.sdk.kotlin.hll.dynamodbmapper.testutils.testSchema
+import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
+import aws.sdk.kotlin.services.dynamodb.model.TransactWriteItem
+import aws.smithy.kotlin.runtime.collections.attributesOf
+import aws.smithy.kotlin.runtime.time.Instant
+import aws.smithy.kotlin.runtime.time.ManualClock
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.time.Duration.Companion.hours
+import aws.sdk.kotlin.services.dynamodb.model.TransactWriteItemsRequest as LowLevelTransactWriteItemsRequest
+
+class TransactWriteItemsTtlInterceptorTest {
+    private val ttlFields = mapOf("expiresAt" to 1.hours.inWholeSeconds)
+    private val schema = ItemSchema(
+        testConverter(),
+        KeySpec.string("id"),
+        attributesOf { SchemaAttributes.TtlFields to ttlFields },
+    )
+
+    @Test
+    fun testSetsTtlOnPutActionsOnly() {
+        val clock = ManualClock(Instant.fromEpochSeconds(0))
+        val interceptor = TtlInterceptor(clock)
+
+        val highLevelRequest = TransactWriteItemsRequest {
+            tables = listOf(
+                TransactWriteItemsRequestTable(
+                    conditionChecks = emptyList(),
+                    deletes = emptyList(),
+                    puts = emptyList(),
+                    schema = schema,
+                    tableName = "table1",
+                    updates = emptyList(),
+                ),
+            )
+        }
+
+        val lowLevelRequest = LowLevelTransactWriteItemsRequest {
+            transactItems = listOf(
+                TransactWriteItem {
+                    put {
+                        tableName = "table1"
+                        item = mapOf("id" to AttributeValue.S("a"))
+                    }
+                },
+                TransactWriteItem {
+                    delete {
+                        tableName = "table1"
+                        key = mapOf("id" to AttributeValue.S("b"))
+                    }
+                },
+            )
+        }
+
+        val result = interceptor.modifyBeforeInvocation(
+            lReqContext(highLevelRequest, lowLevelRequest),
+        ) as LowLevelTransactWriteItemsRequest
+
+        assertEquals(AttributeValue.N("3600"), result.transactItems!![0].put!!.item["expiresAt"])
+        assertNotNull(result.transactItems!![1].delete)
+    }
+
+    @Test
+    fun testAugmentsUpdateActions() {
+        val clock = ManualClock(Instant.fromEpochSeconds(0))
+        val interceptor = TtlInterceptor(clock)
+
+        val seedUpdate = UpdateItemRequest.PartitionKey<KeyType.Key1<String>> {
+            update { set { attr["foo"] = "bar" } }
+        }.update!!
+
+        val highLevelRequest = TransactWriteItemsRequest {
+            tables = listOf(
+                TransactWriteItemsRequestTable(
+                    conditionChecks = emptyList(),
+                    deletes = emptyList(),
+                    puts = emptyList(),
+                    schema = schema,
+                    tableName = "table1",
+                    updates = listOf(TransactWriteItemsAction.Update(null, Key("pk"), null, seedUpdate)),
+                ),
+            )
+        }
+
+        val result = interceptor.modifyBeforeSerialization(hReqContext(highLevelRequest)).highLevelRequest as TransactWriteItemsRequest
+
+        val table = result.tables.single() as TransactWriteItemsRequestTable.PartitionKey<*, *>
+        val update = assertNotNull(table.updates.single().update)
+        val updates = update.set.updates.associateBy { it.target.toString() }
+
+        assertEquals(2, updates.size)
+        assertEquals(UpdateClauseExpr(UpdateAction.SET, AttributePath("foo"), LiteralExpr("bar")), updates["foo"])
+        assertEquals(
+            UpdateClauseExpr(UpdateAction.SET, AttributePath("expiresAt"), LiteralExpr(3600)),
+            updates["expiresAt"],
+        )
+    }
+
+    @Test
+    fun testNoTtlFieldsLeavesUpdatesUnchanged() {
+        val interceptor = TtlInterceptor(ManualClock(Instant.fromEpochSeconds(0)))
+        val schemaWithoutTtl = ItemSchema(testConverter(), KeySpec.string("id"))
+
+        val seedUpdate = UpdateItemRequest.PartitionKey<KeyType.Key1<String>> {
+            update { set { attr["foo"] = "bar" } }
+        }.update!!
+
+        val highLevelRequest = TransactWriteItemsRequest {
+            tables = listOf(
+                TransactWriteItemsRequestTable(
+                    conditionChecks = emptyList(),
+                    deletes = emptyList(),
+                    puts = emptyList(),
+                    schema = schemaWithoutTtl,
+                    tableName = "table1",
+                    updates = listOf(TransactWriteItemsAction.Update(null, Key("pk"), null, seedUpdate)),
+                ),
+            )
+        }
+
+        val result = interceptor.modifyBeforeSerialization(hReqContext(highLevelRequest)).highLevelRequest
+        assertEquals(highLevelRequest, result)
+
+        val table = (result as TransactWriteItemsRequest).tables.single() as TransactWriteItemsRequestTable.PartitionKey<*, *>
+        assertNull(table.updates.single().update.set.updates.associateBy { it.target.toString() }["expiresAt"])
+    }
+
+    @Test
+    fun testNoTtlFieldsIsNoOp() {
+        val interceptor = TtlInterceptor(ManualClock(Instant.fromEpochSeconds(0)))
+        val schemaWithoutTtl = ItemSchema(testConverter(), KeySpec.string("id"))
+
+        val highLevelRequest = TransactWriteItemsRequest {
+            tables = listOf(
+                TransactWriteItemsRequestTable(
+                    conditionChecks = emptyList(),
+                    deletes = emptyList(),
+                    puts = emptyList(),
+                    schema = schemaWithoutTtl,
+                    tableName = "table1",
+                    updates = emptyList(),
+                ),
+            )
+        }
+
+        val lowLevelRequest = LowLevelTransactWriteItemsRequest {
+            transactItems = listOf(
+                TransactWriteItem {
+                    put {
+                        tableName = "table1"
+                        item = mapOf("id" to AttributeValue.S("a"))
+                    }
+                },
+            )
+        }
+
+        val result = interceptor.modifyBeforeInvocation(lReqContext(highLevelRequest, lowLevelRequest))
+        assertSame(lowLevelRequest, result)
+    }
+
+    private fun lReqContext(
+        highLevelRequest: Any,
+        lowLevelRequest: Any,
+    ): LReqContext<Any, ItemSchema<Any>, Any, Any> = LReqContext(highLevelRequest, testSchema { }, testMapperContext(), lowLevelRequest)
+
+    private fun hReqContext(highLevelRequest: Any): HReqContext<Any, ItemSchema<Any>, Any> = HReqContext(highLevelRequest, testSchema { }, testMapperContext())
+}

--- a/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/UpdateItemCounterInterceptorTest.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/UpdateItemCounterInterceptorTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.sdk.kotlin.hll.dynamodbmapper.interceptors
+
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.AdditiveExpr
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.AdditiveOperation
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.AttributePath
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.KeyFilter
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.LiteralExpr
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.ScalarFunc
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.ScalarFuncExpr
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.UpdateAction
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.UpdateClauseExpr
+import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
+import aws.sdk.kotlin.hll.dynamodbmapper.items.KeyType
+import aws.sdk.kotlin.hll.dynamodbmapper.model.SchemaAttributes
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.PartitionKey
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.QueryRequest
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.UpdateItemRequest
+import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.HReqContext
+import aws.sdk.kotlin.hll.dynamodbmapper.testutils.testMapperContext
+import aws.sdk.kotlin.hll.dynamodbmapper.testutils.testSchema
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class UpdateItemCounterInterceptorTest {
+    @Test
+    fun testCounterInterceptor() {
+        val counterFields = setOf("counter1", "counter2")
+        val interceptor = CounterInterceptor()
+
+        val req = UpdateItemRequest.PartitionKey<KeyType.Key1<String>> {
+            update {
+                set {
+                    attr["foo"] = "bar"
+                    attr["baz"] = "qux"
+                }
+            }
+        }
+
+        val ctx = createContext(req, counterFields)
+
+        @Suppress("UNCHECKED_CAST")
+        val result = interceptor.modifyBeforeSerialization(ctx).highLevelRequest as UpdateItemRequest.PartitionKey<KeyType.Key1<String>>
+
+        val updateExpr = assertNotNull(result.update, "Found null update expression")
+        val updates = updateExpr.set.updates.associateBy { it.target.toString() }
+        assertEquals(4, updates.size)
+
+        assertEquals(UpdateClauseExpr(UpdateAction.SET, AttributePath("foo"), LiteralExpr("bar")), updates["foo"])
+        assertEquals(UpdateClauseExpr(UpdateAction.SET, AttributePath("baz"), LiteralExpr("qux")), updates["baz"])
+
+        assertEquals(
+            UpdateClauseExpr(
+                UpdateAction.SET,
+                AttributePath("counter1"),
+                AdditiveExpr(
+                    AdditiveOperation.ADD,
+                    ScalarFuncExpr(
+                        ScalarFunc.IF_NOT_EXISTS,
+                        AttributePath("counter1"),
+                        LiteralExpr(0),
+                    ),
+                    LiteralExpr(1),
+                ),
+            ),
+            updates["counter1"],
+        )
+
+        assertEquals(
+            UpdateClauseExpr(
+                UpdateAction.SET,
+                AttributePath("counter2"),
+                AdditiveExpr(
+                    AdditiveOperation.ADD,
+                    ScalarFuncExpr(
+                        ScalarFunc.IF_NOT_EXISTS,
+                        AttributePath("counter2"),
+                        LiteralExpr(0),
+                    ),
+                    LiteralExpr(1),
+                ),
+            ),
+            updates["counter2"],
+        )
+    }
+
+    @Test
+    fun testCounterInterceptorNoCounterFields() {
+        val interceptor = CounterInterceptor()
+
+        val req = UpdateItemRequest.PartitionKey<KeyType.Key1<String>> {
+            update {
+                set {
+                    attr["foo"] = "bar"
+                    attr["baz"] = "qux"
+                }
+            }
+        }
+
+        val ctx = createContext(req)
+        val result = interceptor.modifyBeforeSerialization(ctx).highLevelRequest
+        assertEquals(req, result)
+    }
+
+    @Test
+    fun testCounterInterceptorNonUpdateItemRequest() {
+        val interceptor = CounterInterceptor()
+
+        val req = QueryRequest.PartitionKey<KeyType.Key1<String>> {
+            keyCondition = KeyFilter("foo")
+            filter {
+                attr["baz"] eq "qux"
+            }
+        }
+
+        val ctx = createContext(req)
+        val result = interceptor.modifyBeforeSerialization(ctx).highLevelRequest
+        assertEquals(req, result)
+    }
+}
+
+private fun createContext(
+    highLevelRequest: Any,
+    counterFields: Set<String>? = null,
+): HReqContext<Any, ItemSchema<Any>, Any> {
+    val schema = testSchema { counterFields?.let { SchemaAttributes.CounterFields to it } }
+    val mapperContext = testMapperContext()
+    return HReqContext(highLevelRequest, schema, mapperContext)
+}

--- a/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/UpdateItemCounterInterceptorTest.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/UpdateItemCounterInterceptorTest.kt
@@ -47,7 +47,7 @@ class UpdateItemCounterInterceptorTest {
         val result = interceptor.modifyBeforeSerialization(ctx).highLevelRequest as UpdateItemRequest.PartitionKey<KeyType.Key1<String>>
 
         val updateExpr = assertNotNull(result.update, "Found null update expression")
-        val updates = updateExpr.set.updates.associateBy { it.target.toString() }
+        val updates = updateExpr.updates.associateBy { it.target.toString() }
         assertEquals(4, updates.size)
 
         assertEquals(UpdateClauseExpr(UpdateAction.SET, AttributePath("foo"), LiteralExpr("bar")), updates["foo"])

--- a/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/UpdateItemTtlInterceptorTest.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/UpdateItemTtlInterceptorTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.sdk.kotlin.hll.dynamodbmapper.interceptors
+
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.AttributePath
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.KeyFilter
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.LiteralExpr
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.UpdateAction
+import aws.sdk.kotlin.hll.dynamodbmapper.expressions.UpdateClauseExpr
+import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
+import aws.sdk.kotlin.hll.dynamodbmapper.items.KeyType
+import aws.sdk.kotlin.hll.dynamodbmapper.model.SchemaAttributes
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.PartitionKey
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.QueryRequest
+import aws.sdk.kotlin.hll.dynamodbmapper.operations.UpdateItemRequest
+import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.HReqContext
+import aws.sdk.kotlin.hll.dynamodbmapper.testutils.testMapperContext
+import aws.sdk.kotlin.hll.dynamodbmapper.testutils.testSchema
+import aws.smithy.kotlin.runtime.time.Instant
+import aws.smithy.kotlin.runtime.time.ManualClock
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.time.Duration.Companion.hours
+
+class UpdateItemTtlInterceptorTest {
+    @Test
+    fun testTtlInterceptor() {
+        val testClock = ManualClock(Instant.fromEpochSeconds(0))
+        val interceptor = TtlInterceptor(testClock)
+        val ttlFields = mapOf("expiresAt" to 1.hours.inWholeSeconds)
+
+        val req = UpdateItemRequest.PartitionKey<KeyType.Key1<String>> {
+            update {
+                set {
+                    attr["foo"] = "bar"
+                    attr["baz"] = "qux"
+                }
+            }
+        }
+
+        val ctx = createContext(req, ttlFields)
+
+        @Suppress("UNCHECKED_CAST")
+        val result1 = interceptor.modifyBeforeSerialization(ctx).highLevelRequest as UpdateItemRequest.PartitionKey<KeyType.Key1<String>>
+
+        val updateExpr1 = assertNotNull(result1.update, "Found null update expression")
+        val updates1 = updateExpr1.set.updates.associateBy { it.target.toString() }
+        assertEquals(3, updates1.size)
+
+        assertEquals(UpdateClauseExpr(UpdateAction.SET, AttributePath("foo"), LiteralExpr("bar")), updates1["foo"])
+        assertEquals(UpdateClauseExpr(UpdateAction.SET, AttributePath("baz"), LiteralExpr("qux")), updates1["baz"])
+        assertEquals(UpdateClauseExpr(UpdateAction.SET, AttributePath("expiresAt"), LiteralExpr(3600)), updates1["expiresAt"])
+
+        testClock.advance(1.hours)
+
+        @Suppress("UNCHECKED_CAST")
+        val result2 = interceptor.modifyBeforeSerialization(ctx).highLevelRequest as UpdateItemRequest.PartitionKey<KeyType.Key1<String>>
+
+        val updateExpr2 = assertNotNull(result2.update, "Found null update expression")
+        val updates2 = updateExpr2.set.updates.associateBy { it.target.toString() }
+        assertEquals(3, updates2.size)
+
+        assertEquals(UpdateClauseExpr(UpdateAction.SET, AttributePath("foo"), LiteralExpr("bar")), updates2["foo"])
+        assertEquals(UpdateClauseExpr(UpdateAction.SET, AttributePath("baz"), LiteralExpr("qux")), updates2["baz"])
+        assertEquals(UpdateClauseExpr(UpdateAction.SET, AttributePath("expiresAt"), LiteralExpr(7200)), updates2["expiresAt"])
+    }
+
+    @Test
+    fun testTtlInterceptorNoTtlFields() {
+        val testClock = ManualClock(Instant.fromEpochSeconds(0))
+        val interceptor = TtlInterceptor(testClock)
+
+        val req = UpdateItemRequest.PartitionKey<KeyType.Key1<String>> {
+            update {
+                set {
+                    attr["foo"] = "bar"
+                    attr["baz"] = "qux"
+                }
+            }
+        }
+
+        val ctx = createContext(req)
+        val result = interceptor.modifyBeforeSerialization(ctx).highLevelRequest
+        assertEquals(req, result)
+    }
+
+    @Test
+    fun testTtlInterceptorNonUpdateItemRequest() {
+        val testClock = ManualClock(Instant.fromEpochSeconds(0))
+        val interceptor = TtlInterceptor(testClock)
+
+        val req = QueryRequest.PartitionKey<KeyType.Key1<String>> {
+            keyCondition = KeyFilter("foo")
+            filter {
+                attr["baz"] eq "qux"
+            }
+        }
+
+        val ctx = createContext(req)
+        val result = interceptor.modifyBeforeSerialization(ctx).highLevelRequest
+        assertEquals(req, result)
+    }
+}
+
+private fun createContext(
+    highLevelRequest: Any,
+    ttlFields: Map<String, Long>? = null,
+): HReqContext<Any, ItemSchema<Any>, Any> {
+    val schema = testSchema { ttlFields?.let { SchemaAttributes.TtlFields to it } }
+    val mapperContext = testMapperContext()
+    return HReqContext(highLevelRequest, schema, mapperContext)
+}

--- a/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/UpdateItemTtlInterceptorTest.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/interceptors/UpdateItemTtlInterceptorTest.kt
@@ -47,7 +47,7 @@ class UpdateItemTtlInterceptorTest {
         val result1 = interceptor.modifyBeforeSerialization(ctx).highLevelRequest as UpdateItemRequest.PartitionKey<KeyType.Key1<String>>
 
         val updateExpr1 = assertNotNull(result1.update, "Found null update expression")
-        val updates1 = updateExpr1.set.updates.associateBy { it.target.toString() }
+        val updates1 = updateExpr1.updates.associateBy { it.target.toString() }
         assertEquals(3, updates1.size)
 
         assertEquals(UpdateClauseExpr(UpdateAction.SET, AttributePath("foo"), LiteralExpr("bar")), updates1["foo"])
@@ -60,7 +60,7 @@ class UpdateItemTtlInterceptorTest {
         val result2 = interceptor.modifyBeforeSerialization(ctx).highLevelRequest as UpdateItemRequest.PartitionKey<KeyType.Key1<String>>
 
         val updateExpr2 = assertNotNull(result2.update, "Found null update expression")
-        val updates2 = updateExpr2.set.updates.associateBy { it.target.toString() }
+        val updates2 = updateExpr2.updates.associateBy { it.target.toString() }
         assertEquals(3, updates2.size)
 
         assertEquals(UpdateClauseExpr(UpdateAction.SET, AttributePath("foo"), LiteralExpr("bar")), updates2["foo"])

--- a/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/testutils/Interceptors.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/testutils/Interceptors.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.sdk.kotlin.hll.dynamodbmapper.testutils
+
+import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemConverter
+import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
+import aws.sdk.kotlin.hll.dynamodbmapper.items.KeySpec
+import aws.sdk.kotlin.hll.dynamodbmapper.model.PersistenceSpec
+import aws.sdk.kotlin.hll.dynamodbmapper.model.buildItem
+import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.MapperContext
+import aws.sdk.kotlin.hll.mapping.core.converters.ConverterImpl
+import aws.smithy.kotlin.runtime.collections.AttributesBuilder
+import aws.smithy.kotlin.runtime.collections.attributesOf
+
+fun testConverter(): ItemConverter<Any> = ConverterImpl(convertRight = { buildItem { } }, convertLeft = { "" })
+
+private val testMapperContext = object : MapperContext<Any> {
+    override val persistenceSpec: PersistenceSpec<Any>
+        get() = error("Not needed for test")
+    override val operation: String
+        get() = error("Not needed for test")
+}
+
+fun testMapperContext(): MapperContext<Any> = testMapperContext
+
+fun testSchema(attributesBlock: AttributesBuilder.() -> Unit) = ItemSchema(
+    testConverter(),
+    KeySpec.string("id"),
+    attributesOf(attributesBlock),
+)

--- a/hll/hll-codegen/src/main/kotlin/aws/sdk/kotlin/hll/codegen/model/Types.kt
+++ b/hll/hll-codegen/src/main/kotlin/aws/sdk/kotlin/hll/codegen/model/Types.kt
@@ -47,6 +47,7 @@ public object Types {
         public object Collections {
             public val List: TypeRef = TypeRef(Pkg.Kotlin.Collections, "List")
             public val Map: TypeRef = TypeRef(Pkg.Kotlin.Collections, "Map")
+            public val mapOf: TypeRef = TypeRef(Pkg.Kotlin.Collections, "mapOf")
             public val Set: TypeRef = TypeRef(Pkg.Kotlin.Collections, "Set")
             public val setOf: TypeRef = TypeRef(Pkg.Kotlin.Collections, "setOf")
         }


### PR DESCRIPTION
## Issue \#

Related to #472 

## Description of changes

This change expands the utilization of `CounterInterceptor` and `TtlInterceptor` to cover the new mutating operations `UpdateItem`, `BatchWriteItem`, and `TransactWriteItems`. As part of this work a few other related changes were made:
* During testing, it became apparent that the `update { }` DSL's previous behavior of _replacing_ any prior updates was flawed. This PR updates `update` (heh!) to _append_ to any prior updates rather than replace.
* Changed the type of attribute `TtlFields` from `Set<Pair<String, Long>>>` to `Map<String, Long>`. Maps are more natural & idiomatic than sets of pairs and the single-value-per-key constraint matches the intended use case better (sets of pairs allow duplicated keys).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
