### PR TITLE
Cleanup todos and fixmes

### DIFF
--- a/hll/ddb-mapper/dynamodb-mapper-ops-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/operations/HighLevelOpsProcessor.kt
+++ b/hll/ddb-mapper/dynamodb-mapper-ops-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/operations/HighLevelOpsProcessor.kt
@@ -15,6 +15,7 @@ import aws.sdk.kotlin.hll.dynamodbmapper.codegen.operations.rendering.HighLevelR
 import aws.sdk.kotlin.services.dynamodb.DynamoDbClient
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.getDeclaredFunctions
+import com.google.devtools.ksp.processing.Dependencies
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.symbol.KSAnnotated
@@ -31,14 +32,20 @@ internal class HighLevelOpsProcessor(environment: SymbolProcessorEnvironment) : 
     private val opAllowlist = environment.options["op-allowlist"]?.split(";")
     private val pkg = environment.options["pkg"] ?: MapperPkg.Hl.Ops.Base
 
-    private val ctx by lazy {
-        val codegenFactory = CodeGeneratorFactory(codeGenerator, logger) // FIXME Pass dependencies
-        RenderContext(logger, codegenFactory, pkg, "dynamodb-mapper-ops-codegen")
-    }
-
     override fun processImpl(resolver: Resolver): List<KSAnnotated> {
         logger.info("Scanning low-level DDB client for operations and types")
-        val operations = getOperations(resolver)
+        val operationFunctions = resolver
+            .getClassDeclarationByName<DynamoDbClient>()!!
+            .getDeclaredFunctions()
+            .filter(::allow)
+
+        val dependencyFiles = operationFunctions.mapNotNull { it.containingFile }
+        val codegenDeps = Dependencies(aggregating = false, sources = dependencyFiles.toList().toTypedArray())
+        logger.info("Found dependency files:\n${codegenDeps.originatingFiles.joinToString("\n") { it.filePath }}")
+
+        val codegenFactory = CodeGeneratorFactory(codeGenerator, logger, codegenDeps)
+        val ctx = RenderContext(logger, codegenFactory, pkg, "dynamodb-mapper-ops-codegen")
+        val operations = getOperations(resolver, ctx)
 
         logger.info("Rendering high-level operations and types for ${operations.map { it.name }}")
         HighLevelRenderer(ctx, operations).render()
@@ -59,7 +66,7 @@ internal class HighLevelOpsProcessor(environment: SymbolProcessorEnvironment) : 
         return allowed ?: true
     }
 
-    private fun getOperations(resolver: Resolver): List<Operation> = resolver
+    private fun getOperations(resolver: Resolver, ctx: RenderContext): List<Operation> = resolver
         .getClassDeclarationByName<DynamoDbClient>()!!
         .getDeclaredFunctions()
         .filter(::allow)

--- a/hll/ddb-mapper/dynamodb-mapper-ops-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/operations/HighLevelOpsProcessor.kt
+++ b/hll/ddb-mapper/dynamodb-mapper-ops-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/operations/HighLevelOpsProcessor.kt
@@ -45,7 +45,11 @@ internal class HighLevelOpsProcessor(environment: SymbolProcessorEnvironment) : 
 
         val codegenFactory = CodeGeneratorFactory(codeGenerator, logger, codegenDeps)
         val ctx = RenderContext(logger, codegenFactory, pkg, "dynamodb-mapper-ops-codegen")
-        val operations = getOperations(resolver, ctx)
+
+        val operations = operationFunctions
+            .map(Operation::from)
+            .map { it.toHighLevel(ctx) }
+            .toList()
 
         logger.info("Rendering high-level operations and types for ${operations.map { it.name }}")
         HighLevelRenderer(ctx, operations).render()
@@ -65,12 +69,4 @@ internal class HighLevelOpsProcessor(environment: SymbolProcessorEnvironment) : 
 
         return allowed ?: true
     }
-
-    private fun getOperations(resolver: Resolver, ctx: RenderContext): List<Operation> = resolver
-        .getClassDeclarationByName<DynamoDbClient>()!!
-        .getDeclaredFunctions()
-        .filter(::allow)
-        .map(Operation::from)
-        .map { it.toHighLevel(ctx) }
-        .toList()
 }

--- a/hll/ddb-mapper/dynamodb-mapper-ops-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/operations/model/MemberCodegenBehavior.kt
+++ b/hll/ddb-mapper/dynamodb-mapper-ops-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/operations/model/MemberCodegenBehavior.kt
@@ -91,10 +91,8 @@ internal sealed interface MemberCodegenBehavior {
  * Identifies a type of expression literal supported by DynamoDB APIs
  */
 internal enum class ExpressionLiteralType {
-    Condition,
     Filter,
     KeyCondition,
-    Projection,
     Update,
 }
 
@@ -330,10 +328,6 @@ private val rules = listOf(
     Rule("keyConditionExpression", Types.Kotlin.String, ExpressionLiteral(KeyCondition)),
     Rule("filterExpression", Types.Kotlin.String, ExpressionLiteral(Filter)),
     Rule("updateExpression", Types.Kotlin.String, ExpressionLiteral(Update)),
-
-    // TODO add support for remaining expression types
-    Rule("conditionExpression", Types.Kotlin.String, Drop),
-    Rule("projectionExpression", Types.Kotlin.String, Drop),
 
     // Expression arguments
     Rule("expressionAttributeNames", Types.Kotlin.stringMap(Types.Kotlin.String), ExpressionArguments(AttributeNames)),

--- a/hll/ddb-mapper/dynamodb-mapper-ops-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/operations/model/MemberCodegenBehavior.kt
+++ b/hll/ddb-mapper/dynamodb-mapper-ops-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/operations/model/MemberCodegenBehavior.kt
@@ -301,7 +301,7 @@ private val transactWriteItemsRequestTables = CustomTransformation(
  * successfully matches with a member will be chosen.
  */
 private val rules = listOf(
-    // Deprecated expression members not to be carried forward into HLL
+    // Deprecated and/or unsupported expression members not to be carried forward into HLL
     Rule("conditionalOperator", llType("ConditionalOperator"), Drop),
     Rule("expected", Types.Kotlin.stringMap(llType("ExpectedAttributeValue")), Drop),
     Rule("queryFilter", Types.Kotlin.stringMap(llType("Condition")), Drop),
@@ -309,6 +309,7 @@ private val rules = listOf(
     Rule("keyConditions", Types.Kotlin.stringMap(llType("Condition")), Drop),
     Rule("attributesToGet", Types.Kotlin.list(Types.Kotlin.String), Drop),
     Rule("attributeUpdates", Types.Kotlin.stringMap(llType("AttributeValueUpdate")), Drop),
+    Rule("projectionExpression", Types.Kotlin.String, Drop),
 
     // Hoisted members
     Rule("tableName", Types.Kotlin.String, Hoist),
@@ -326,7 +327,7 @@ private val rules = listOf(
 
     // Expression literals
     Rule("keyConditionExpression", Types.Kotlin.String, ExpressionLiteral(KeyCondition)),
-    Rule("filterExpression", Types.Kotlin.String, ExpressionLiteral(Filter)),
+    Rule("filterExpression|conditionExpression".toRegex(), Types.Kotlin.String, ExpressionLiteral(Filter)),
     Rule("updateExpression", Types.Kotlin.String, ExpressionLiteral(Update)),
 
     // Expression arguments

--- a/hll/ddb-mapper/dynamodb-mapper-ops-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/operations/model/Structure.kt
+++ b/hll/ddb-mapper/dynamodb-mapper-ops-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/operations/model/Structure.kt
@@ -68,9 +68,6 @@ private fun deriveExpressionLiteral(llMember: Member, type: ExpressionLiteralTyp
         ExpressionLiteralType.Filter -> MapperTypes.Expressions.BooleanExpr
         ExpressionLiteralType.KeyCondition -> MapperTypes.Expressions.KeyFilter
         ExpressionLiteralType.Update -> MapperTypes.Expressions.UpdateExpr
-
-        // TODO add support for other expression types
-        else -> return null
     }.nullable(llMember.type.nullable)
 
     val dslInfo = when (type) {

--- a/hll/ddb-mapper/dynamodb-mapper-ops-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/operations/rendering/OperationsTypeRenderer.kt
+++ b/hll/ddb-mapper/dynamodb-mapper-ops-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/operations/rendering/OperationsTypeRenderer.kt
@@ -27,7 +27,6 @@ internal class OperationsTypeRenderer(
     private val operations: List<Operation>,
 ) : RendererBase(ctx, "${itemSourceKind.name}Operations") {
     private companion object {
-        // FIXME Support unsigned number types?
         val keyDataTypes = listOf(
             Types.Kotlin.Byte,
             Types.Kotlin.ByteArray,

--- a/hll/ddb-mapper/dynamodb-mapper-schema-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/annotations/rendering/SchemaRenderer.kt
+++ b/hll/ddb-mapper/dynamodb-mapper-schema-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/annotations/rendering/SchemaRenderer.kt
@@ -154,7 +154,6 @@ internal class SchemaRenderer(
      * with our [ItemToValueConverter]
      */
     private fun renderValueConverter() {
-        // TODO Offer alternate serialization options besides AttributeValue.M?
         generatedAnnotation()
         write(
             "#Lval #L: #T = #T(#T, #T)",

--- a/hll/ddb-mapper/dynamodb-mapper/api/dynamodb-mapper.api
+++ b/hll/ddb-mapper/dynamodb-mapper/api/dynamodb-mapper.api
@@ -1601,6 +1601,7 @@ public final class aws/sdk/kotlin/hll/dynamodbmapper/operations/BatchWriteItemRe
 
 public abstract interface class aws/sdk/kotlin/hll/dynamodbmapper/operations/DeleteItemRequest {
 	public static final field Companion Laws/sdk/kotlin/hll/dynamodbmapper/operations/DeleteItemRequest$Companion;
+	public abstract fun getCondition ()Laws/sdk/kotlin/hll/dynamodbmapper/expressions/BooleanExpr;
 	public abstract fun getReturnConsumedCapacity ()Laws/sdk/kotlin/services/dynamodb/model/ReturnConsumedCapacity;
 	public abstract fun getReturnItemCollectionMetrics ()Laws/sdk/kotlin/services/dynamodb/model/ReturnItemCollectionMetrics;
 	public abstract fun getReturnValues ()Laws/sdk/kotlin/services/dynamodb/model/ReturnValue;
@@ -1630,12 +1631,15 @@ public final class aws/sdk/kotlin/hll/dynamodbmapper/operations/DeleteItemReques
 public final class aws/sdk/kotlin/hll/dynamodbmapper/operations/DeleteItemRequestCompositeKeyBuilder {
 	public fun <init> ()V
 	public final fun build ()Laws/sdk/kotlin/hll/dynamodbmapper/operations/DeleteItemRequest$CompositeKey;
+	public final fun condition (Lkotlin/jvm/functions/Function1;)V
+	public final fun getCondition ()Laws/sdk/kotlin/hll/dynamodbmapper/expressions/BooleanExpr;
 	public final fun getPartitionKey ()Laws/sdk/kotlin/hll/dynamodbmapper/items/KeyType;
 	public final fun getReturnConsumedCapacity ()Laws/sdk/kotlin/services/dynamodb/model/ReturnConsumedCapacity;
 	public final fun getReturnItemCollectionMetrics ()Laws/sdk/kotlin/services/dynamodb/model/ReturnItemCollectionMetrics;
 	public final fun getReturnValues ()Laws/sdk/kotlin/services/dynamodb/model/ReturnValue;
 	public final fun getReturnValuesOnConditionCheckFailure ()Laws/sdk/kotlin/services/dynamodb/model/ReturnValuesOnConditionCheckFailure;
 	public final fun getSortKey ()Laws/sdk/kotlin/hll/dynamodbmapper/items/KeyType;
+	public final fun setCondition (Laws/sdk/kotlin/hll/dynamodbmapper/expressions/BooleanExpr;)V
 	public final fun setPartitionKey (Laws/sdk/kotlin/hll/dynamodbmapper/items/KeyType;)V
 	public final fun setReturnConsumedCapacity (Laws/sdk/kotlin/services/dynamodb/model/ReturnConsumedCapacity;)V
 	public final fun setReturnItemCollectionMetrics (Laws/sdk/kotlin/services/dynamodb/model/ReturnItemCollectionMetrics;)V
@@ -1656,11 +1660,14 @@ public final class aws/sdk/kotlin/hll/dynamodbmapper/operations/DeleteItemReques
 public final class aws/sdk/kotlin/hll/dynamodbmapper/operations/DeleteItemRequestPartitionKeyBuilder {
 	public fun <init> ()V
 	public final fun build ()Laws/sdk/kotlin/hll/dynamodbmapper/operations/DeleteItemRequest$PartitionKey;
+	public final fun condition (Lkotlin/jvm/functions/Function1;)V
+	public final fun getCondition ()Laws/sdk/kotlin/hll/dynamodbmapper/expressions/BooleanExpr;
 	public final fun getPartitionKey ()Laws/sdk/kotlin/hll/dynamodbmapper/items/KeyType;
 	public final fun getReturnConsumedCapacity ()Laws/sdk/kotlin/services/dynamodb/model/ReturnConsumedCapacity;
 	public final fun getReturnItemCollectionMetrics ()Laws/sdk/kotlin/services/dynamodb/model/ReturnItemCollectionMetrics;
 	public final fun getReturnValues ()Laws/sdk/kotlin/services/dynamodb/model/ReturnValue;
 	public final fun getReturnValuesOnConditionCheckFailure ()Laws/sdk/kotlin/services/dynamodb/model/ReturnValuesOnConditionCheckFailure;
+	public final fun setCondition (Laws/sdk/kotlin/hll/dynamodbmapper/expressions/BooleanExpr;)V
 	public final fun setPartitionKey (Laws/sdk/kotlin/hll/dynamodbmapper/items/KeyType;)V
 	public final fun setReturnConsumedCapacity (Laws/sdk/kotlin/services/dynamodb/model/ReturnConsumedCapacity;)V
 	public final fun setReturnItemCollectionMetrics (Laws/sdk/kotlin/services/dynamodb/model/ReturnItemCollectionMetrics;)V
@@ -2001,6 +2008,7 @@ public final class aws/sdk/kotlin/hll/dynamodbmapper/operations/ItemSourceOperat
 
 public abstract interface class aws/sdk/kotlin/hll/dynamodbmapper/operations/PutItemRequest {
 	public static final field Companion Laws/sdk/kotlin/hll/dynamodbmapper/operations/PutItemRequest$Companion;
+	public abstract fun getCondition ()Laws/sdk/kotlin/hll/dynamodbmapper/expressions/BooleanExpr;
 	public abstract fun getItem ()Ljava/lang/Object;
 	public abstract fun getReturnConsumedCapacity ()Laws/sdk/kotlin/services/dynamodb/model/ReturnConsumedCapacity;
 	public abstract fun getReturnItemCollectionMetrics ()Laws/sdk/kotlin/services/dynamodb/model/ReturnItemCollectionMetrics;
@@ -2014,11 +2022,14 @@ public final class aws/sdk/kotlin/hll/dynamodbmapper/operations/PutItemRequest$C
 public final class aws/sdk/kotlin/hll/dynamodbmapper/operations/PutItemRequestBuilder {
 	public fun <init> ()V
 	public final fun build ()Laws/sdk/kotlin/hll/dynamodbmapper/operations/PutItemRequest;
+	public final fun condition (Lkotlin/jvm/functions/Function1;)V
+	public final fun getCondition ()Laws/sdk/kotlin/hll/dynamodbmapper/expressions/BooleanExpr;
 	public final fun getItem ()Ljava/lang/Object;
 	public final fun getReturnConsumedCapacity ()Laws/sdk/kotlin/services/dynamodb/model/ReturnConsumedCapacity;
 	public final fun getReturnItemCollectionMetrics ()Laws/sdk/kotlin/services/dynamodb/model/ReturnItemCollectionMetrics;
 	public final fun getReturnValues ()Laws/sdk/kotlin/services/dynamodb/model/ReturnValue;
 	public final fun getReturnValuesOnConditionCheckFailure ()Laws/sdk/kotlin/services/dynamodb/model/ReturnValuesOnConditionCheckFailure;
+	public final fun setCondition (Laws/sdk/kotlin/hll/dynamodbmapper/expressions/BooleanExpr;)V
 	public final fun setItem (Ljava/lang/Object;)V
 	public final fun setReturnConsumedCapacity (Laws/sdk/kotlin/services/dynamodb/model/ReturnConsumedCapacity;)V
 	public final fun setReturnItemCollectionMetrics (Laws/sdk/kotlin/services/dynamodb/model/ReturnItemCollectionMetrics;)V
@@ -2815,6 +2826,7 @@ public final class aws/sdk/kotlin/hll/dynamodbmapper/operations/TransactWriteIte
 
 public abstract interface class aws/sdk/kotlin/hll/dynamodbmapper/operations/UpdateItemRequest {
 	public static final field Companion Laws/sdk/kotlin/hll/dynamodbmapper/operations/UpdateItemRequest$Companion;
+	public abstract fun getCondition ()Laws/sdk/kotlin/hll/dynamodbmapper/expressions/BooleanExpr;
 	public abstract fun getReturnConsumedCapacity ()Laws/sdk/kotlin/services/dynamodb/model/ReturnConsumedCapacity;
 	public abstract fun getReturnItemCollectionMetrics ()Laws/sdk/kotlin/services/dynamodb/model/ReturnItemCollectionMetrics;
 	public abstract fun getReturnValues ()Laws/sdk/kotlin/services/dynamodb/model/ReturnValue;
@@ -2845,6 +2857,8 @@ public final class aws/sdk/kotlin/hll/dynamodbmapper/operations/UpdateItemReques
 public final class aws/sdk/kotlin/hll/dynamodbmapper/operations/UpdateItemRequestCompositeKeyBuilder {
 	public fun <init> ()V
 	public final fun build ()Laws/sdk/kotlin/hll/dynamodbmapper/operations/UpdateItemRequest$CompositeKey;
+	public final fun condition (Lkotlin/jvm/functions/Function1;)V
+	public final fun getCondition ()Laws/sdk/kotlin/hll/dynamodbmapper/expressions/BooleanExpr;
 	public final fun getPartitionKey ()Laws/sdk/kotlin/hll/dynamodbmapper/items/KeyType;
 	public final fun getReturnConsumedCapacity ()Laws/sdk/kotlin/services/dynamodb/model/ReturnConsumedCapacity;
 	public final fun getReturnItemCollectionMetrics ()Laws/sdk/kotlin/services/dynamodb/model/ReturnItemCollectionMetrics;
@@ -2852,6 +2866,7 @@ public final class aws/sdk/kotlin/hll/dynamodbmapper/operations/UpdateItemReques
 	public final fun getReturnValuesOnConditionCheckFailure ()Laws/sdk/kotlin/services/dynamodb/model/ReturnValuesOnConditionCheckFailure;
 	public final fun getSortKey ()Laws/sdk/kotlin/hll/dynamodbmapper/items/KeyType;
 	public final fun getUpdate ()Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr;
+	public final fun setCondition (Laws/sdk/kotlin/hll/dynamodbmapper/expressions/BooleanExpr;)V
 	public final fun setPartitionKey (Laws/sdk/kotlin/hll/dynamodbmapper/items/KeyType;)V
 	public final fun setReturnConsumedCapacity (Laws/sdk/kotlin/services/dynamodb/model/ReturnConsumedCapacity;)V
 	public final fun setReturnItemCollectionMetrics (Laws/sdk/kotlin/services/dynamodb/model/ReturnItemCollectionMetrics;)V
@@ -2874,12 +2889,15 @@ public final class aws/sdk/kotlin/hll/dynamodbmapper/operations/UpdateItemReques
 public final class aws/sdk/kotlin/hll/dynamodbmapper/operations/UpdateItemRequestPartitionKeyBuilder {
 	public fun <init> ()V
 	public final fun build ()Laws/sdk/kotlin/hll/dynamodbmapper/operations/UpdateItemRequest$PartitionKey;
+	public final fun condition (Lkotlin/jvm/functions/Function1;)V
+	public final fun getCondition ()Laws/sdk/kotlin/hll/dynamodbmapper/expressions/BooleanExpr;
 	public final fun getPartitionKey ()Laws/sdk/kotlin/hll/dynamodbmapper/items/KeyType;
 	public final fun getReturnConsumedCapacity ()Laws/sdk/kotlin/services/dynamodb/model/ReturnConsumedCapacity;
 	public final fun getReturnItemCollectionMetrics ()Laws/sdk/kotlin/services/dynamodb/model/ReturnItemCollectionMetrics;
 	public final fun getReturnValues ()Laws/sdk/kotlin/services/dynamodb/model/ReturnValue;
 	public final fun getReturnValuesOnConditionCheckFailure ()Laws/sdk/kotlin/services/dynamodb/model/ReturnValuesOnConditionCheckFailure;
 	public final fun getUpdate ()Laws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateExpr;
+	public final fun setCondition (Laws/sdk/kotlin/hll/dynamodbmapper/expressions/BooleanExpr;)V
 	public final fun setPartitionKey (Laws/sdk/kotlin/hll/dynamodbmapper/items/KeyType;)V
 	public final fun setReturnConsumedCapacity (Laws/sdk/kotlin/services/dynamodb/model/ReturnConsumedCapacity;)V
 	public final fun setReturnItemCollectionMetrics (Laws/sdk/kotlin/services/dynamodb/model/ReturnItemCollectionMetrics;)V

--- a/hll/ddb-mapper/dynamodb-mapper/api/dynamodb-mapper.api
+++ b/hll/ddb-mapper/dynamodb-mapper/api/dynamodb-mapper.api
@@ -1240,12 +1240,34 @@ public final class aws/sdk/kotlin/hll/dynamodbmapper/items/KeyTypeKt {
 }
 
 public final class aws/sdk/kotlin/hll/dynamodbmapper/items/SimpleItemConverter : aws/sdk/kotlin/hll/mapping/core/converters/Converter {
-	public fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;[Laws/sdk/kotlin/hll/dynamodbmapper/items/AttributeDescriptor;)V
+	public fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;[Laws/sdk/kotlin/hll/dynamodbmapper/items/AttributeDescriptor;Laws/sdk/kotlin/hll/dynamodbmapper/items/UnknownValueHandling;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;[Laws/sdk/kotlin/hll/dynamodbmapper/items/AttributeDescriptor;Laws/sdk/kotlin/hll/dynamodbmapper/items/UnknownValueHandling;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun convertLeft (Laws/sdk/kotlin/hll/dynamodbmapper/model/Item;)Ljava/lang/Object;
 	public synthetic fun convertLeft (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun convertRight (Ljava/lang/Object;)Laws/sdk/kotlin/hll/dynamodbmapper/model/Item;
 	public synthetic fun convertRight (Ljava/lang/Object;)Ljava/lang/Object;
 	public final fun getDescriptors ()Ljava/util/Map;
+}
+
+public abstract interface class aws/sdk/kotlin/hll/dynamodbmapper/items/UnknownValueHandling {
+}
+
+public abstract interface class aws/sdk/kotlin/hll/dynamodbmapper/items/UnknownValueHandling$Custom : aws/sdk/kotlin/hll/dynamodbmapper/items/UnknownValueHandling {
+	public abstract fun handleUnknown (Ljava/lang/String;Laws/sdk/kotlin/services/dynamodb/model/AttributeValue;Ljava/lang/Object;)V
+}
+
+public final class aws/sdk/kotlin/hll/dynamodbmapper/items/UnknownValueHandling$Ignore : aws/sdk/kotlin/hll/dynamodbmapper/items/UnknownValueHandling {
+	public static final field INSTANCE Laws/sdk/kotlin/hll/dynamodbmapper/items/UnknownValueHandling$Ignore;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class aws/sdk/kotlin/hll/dynamodbmapper/items/UnknownValueHandling$ThrowException : aws/sdk/kotlin/hll/dynamodbmapper/items/UnknownValueHandling {
+	public static final field INSTANCE Laws/sdk/kotlin/hll/dynamodbmapper/items/UnknownValueHandling$ThrowException;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class aws/sdk/kotlin/hll/dynamodbmapper/model/Index : aws/sdk/kotlin/hll/dynamodbmapper/model/IndexSpec, aws/sdk/kotlin/hll/dynamodbmapper/model/ItemSource, aws/sdk/kotlin/hll/dynamodbmapper/operations/IndexOperations {

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/DynamoDbMapper.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/DynamoDbMapper.kt
@@ -61,8 +61,6 @@ public interface DynamoDbMapper : DynamoDbMapperOperations {
         schema: ItemSchema.CompositeKey<T, PK, SK>,
     ): Table.CompositeKey<T, PK, SK>
 
-    // TODO add multi-table operations like batchGetItem, transactWriteItems, etc.
-
     /**
      * The immutable configuration for a [DynamoDbMapper] instance
      */

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/FilterDsl.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/FilterDsl.kt
@@ -655,9 +655,6 @@ public interface FilterDsl {
      */
     public fun AttributePath.isBetween(min: ByteArray, max: ByteArray): BooleanExpr = isBetween(LiteralExpr(min), LiteralExpr(max))
 
-    // TODO The following overloads support [ClosedRange] but [OpenEndRange] also exists. DynamoDB expressions don't
-    //  support it directly but we may be able to cheese it with two inequalities ANDed together.
-
     /**
      * Creates a range expression for verifying this expression is in the given range
      * @param range The range to check

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/KeyConversion.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/KeyConversion.kt
@@ -135,7 +135,6 @@ internal fun <SK : KeyType> itemToSk(
  * @param schema The composite key schema
  * @param item The item containing the key value(s)
  */
-@JvmName("itemToCkNonNull")
 internal fun <PK : KeyType, SK : KeyType> itemToCk(
     schema: ItemSchema.CompositeKey<*, PK, SK>,
     item: Item,

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/KeyConversion.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/KeyConversion.kt
@@ -142,23 +142,14 @@ internal fun <PK : KeyType, SK : KeyType> itemToCk(
 ): Pair<PK, SK> = itemToPk(schema, item) to itemToSk(schema, item)
 
 /**
- * Converts the given [Item] into a partition key and sort key with the given schema
- * @param schema The composite key schema
- * @param item The item containing the key value(s)
- */
-@JvmName("itemToCkNullable")
-internal fun <PK : KeyType, SK : KeyType> itemToCk(
-    schema: ItemSchema.CompositeKey<*, PK, SK>,
-    item: Item?,
-): Pair<PK, SK>? = item?.let { itemToPk(schema, item) to itemToSk(schema, item) }
-
-/**
  * Extracts the partition key an entity of type [T] using the given schema
  * @param schema The partition key schema
  * @param entity The entity from which to extract the key
  */
-internal fun <T, PK : KeyType> entityToPk(schema: ItemSchema.PartitionKey<T, PK>, entity: T): PK =
-    schema.partitionKey.converter.convertLeft(schema.converter.convertRight(entity))
+internal fun <T, PK : KeyType> entityToPk(schema: ItemSchema.PartitionKey<T, PK>, entity: T): PK = schema
+    .partitionKey
+    .converter
+    .convertLeft(schema.converter.convertRight(entity))
 
 /**
  * Extracts the composite key an entity of type [T] using the given schema

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/KeyConversion.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/KeyConversion.kt
@@ -157,7 +157,7 @@ internal fun <PK : KeyType, SK : KeyType> itemToCk(
  * @param schema The partition key schema
  * @param entity The entity from which to extract the key
  */
-internal fun <T, PK : KeyType> entityToPk(schema: ItemSchema.PartitionKey<T, PK>, entity: T): PK = // TODO make this more efficient
+internal fun <T, PK : KeyType> entityToPk(schema: ItemSchema.PartitionKey<T, PK>, entity: T): PK =
     schema.partitionKey.converter.convertLeft(schema.converter.convertRight(entity))
 
 /**
@@ -169,7 +169,6 @@ internal fun <T, PK : KeyType, SK : KeyType> entityToCk(
     schema: ItemSchema.CompositeKey<T, PK, SK>,
     entity: T,
 ): Pair<PK, SK> {
-    // TODO make this more efficient
     val fullItem = schema.converter.convertRight(entity)
     val pk = schema.partitionKey.converter.convertLeft(fullItem)
     val sk = schema.sortKey.converter.convertLeft(fullItem)

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/SimpleItemConverter.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/SimpleItemConverter.kt
@@ -20,11 +20,14 @@ import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
  * @param build A method which builds a builder object of type [B] into its final representation of type [T]. If [B] and
  * [T] are the same type, this may be an identity function.
  * @param descriptors A collection of [AttributeDescriptor] which describe how to construct and parse attributes
+ * @param unknownValueHandling Identifies how to handle attributes whose keys do not appear in the [descriptors] list.
+ * The default value is [UnknownValueHandling.Ignore], which will silently ignore unknown attributes.
  */
 public class SimpleItemConverter<T, B>(
     private val builderFactory: () -> B,
     private val build: B.() -> T,
     vararg descriptors: AttributeDescriptor<*, T, B>,
+    private val unknownValueHandling: UnknownValueHandling<B> = UnknownValueHandling.Ignore,
 ) : ItemConverter<T> {
     public val descriptors: Map<String, AttributeDescriptor<*, T, B>> = descriptors
         .groupBy { it.name }
@@ -43,15 +46,23 @@ public class SimpleItemConverter<T, B>(
          *
          * ```kotlin
          * val descriptor = descriptors[name] // AttributeDescriptor<*, T, B>
-         * val value = descriptor.converter.fromAttributeValue(av) // Any?
+         * val value = descriptor.converter.convertLeft(av) // Any?
          * descriptor.setter(builder, value) // Type mismatch for value. Required: Nothing, Found: Any?
          * ```
          */
         fun <A> AttributeDescriptor<A, T, B>.fromAttributeValue(attr: AttributeValue) = builder.setter(converter.convertLeft(attr))
 
         from.forEach { (name, attr) ->
-            // TODO make behavior for unknown attributes configurable (ignore, exception, other?)
-            this.descriptors[name]?.fromAttributeValue(attr)
+            val descriptor = descriptors[name]
+            if (descriptor == null) {
+                when (unknownValueHandling) {
+                    UnknownValueHandling.Ignore -> { }
+                    UnknownValueHandling.ThrowException -> throw IllegalArgumentException("""Unknown attribute "$name"""")
+                    is UnknownValueHandling.Custom<B> -> unknownValueHandling.handleUnknown(name, attr, builder)
+                }
+            } else {
+                descriptor.fromAttributeValue(attr)
+            }
         }
 
         return builder.build()

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/UnknownValueHandling.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/UnknownValueHandling.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package aws.sdk.kotlin.hll.dynamodbmapper.items
+
+import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
+
+/**
+ * Identifies how to handle attributes whose keys aren't in an item schema when converting from an item to an entity
+ * type
+ * @param B The type of builder object used to construct instances of the entity type
+ */
+public sealed interface UnknownValueHandling<out B> {
+    /**
+     * Indicates that unknown attributes should be ignored
+     */
+    public data object Ignore : UnknownValueHandling<Nothing>
+
+    /**
+     * Indicates that unknown attributes should cause an exception to be thrown
+     */
+    public data object ThrowException : UnknownValueHandling<Nothing>
+
+    /**
+     * Indicates that unknown attributes should be passed to a user-defined function for custom handling
+     */
+    public fun interface Custom<B> : UnknownValueHandling<B> {
+        /**
+         * Handle an attribute whose key isn't present in an item schema. Implementations may throw exceptions (which
+         * causes item conversion to fail), take no action, or take action on the [builder] to read/update entity
+         * properties.
+         * @param name The key of the attribute
+         * @param value The value of the attribute
+         * @param builder An instance of a builder object being used to construct an entity type, which may be used to
+         * read and set entity properties
+         */
+        public fun handleUnknown(name: String, value: AttributeValue, builder: B)
+    }
+}

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/pipeline/MapperContext.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/pipeline/MapperContext.kt
@@ -12,8 +12,6 @@ import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.internal.MapperContextImpl
  * @param T The type of objects being converted to/from DynamoDB items
  */
 public interface MapperContext<T> {
-    // TODO what other fields would be useful in here?
-
     /**
      * The metadata about an operation invocation
      */

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/util/AttributeValues.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/util/AttributeValues.kt
@@ -64,7 +64,7 @@ internal fun dynamicAv(value: Any?): AttributeValue = when (value) {
     is Map<*, *> -> av(value as Map<String, Any?>)
     is Number -> av(value)
     is Set<*> -> when (val type = value.firstOrNull()) { // Attempt to determine set type by first element
-        null -> av(value as Set<String>) // FIXME Is this a bad idea for the empty set case?
+        null -> av(value as Set<String>)
         is ByteArray -> av(value as Set<ByteArray>)
         is Number -> av(value as Set<Number>)
         is String -> av(value as Set<String>)
@@ -74,6 +74,7 @@ internal fun dynamicAv(value: Any?): AttributeValue = when (value) {
         is UShort -> av(value as Set<UShort>)
         else -> error("Unsupported set element type $type")
     }
+
     is String -> av(value)
     else -> error("Unsupported attribute value type ${value::class}")
 }

--- a/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/items/SimpleItemConverterTest.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/items/SimpleItemConverterTest.kt
@@ -6,12 +6,10 @@ package aws.sdk.kotlin.hll.dynamodbmapper.items
 
 import aws.sdk.kotlin.hll.dynamodbmapper.model.intersectKeys
 import aws.sdk.kotlin.hll.dynamodbmapper.model.itemOf
-import aws.sdk.kotlin.hll.dynamodbmapper.util.av
 import aws.sdk.kotlin.hll.dynamodbmapper.values.scalars.BooleanValueConverter
 import aws.sdk.kotlin.hll.dynamodbmapper.values.scalars.NumberValueConverters
 import aws.sdk.kotlin.hll.dynamodbmapper.values.scalars.StringValueConverter
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
-import kotlinx.coroutines.channels.ProducerScope
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith

--- a/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/items/SimpleItemConverterTest.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/items/SimpleItemConverterTest.kt
@@ -5,11 +5,16 @@
 package aws.sdk.kotlin.hll.dynamodbmapper.items
 
 import aws.sdk.kotlin.hll.dynamodbmapper.model.intersectKeys
+import aws.sdk.kotlin.hll.dynamodbmapper.model.itemOf
+import aws.sdk.kotlin.hll.dynamodbmapper.util.av
 import aws.sdk.kotlin.hll.dynamodbmapper.values.scalars.BooleanValueConverter
 import aws.sdk.kotlin.hll.dynamodbmapper.values.scalars.NumberValueConverters
 import aws.sdk.kotlin.hll.dynamodbmapper.values.scalars.StringValueConverter
+import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
+import kotlinx.coroutines.channels.ProducerScope
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class SimpleItemConverterTest {
@@ -51,6 +56,63 @@ class SimpleItemConverterTest {
         assertEquals(2, item.size)
         assertEquals(42, item.getValue("id").asN().toInt())
         assertEquals("Foo 2.0", item.getValue("name").asS())
+    }
+
+    @Test
+    fun testUnknownAttributesThrowExceptions() {
+        val converter = SimpleItemConverter(
+            ::ProductBuilder,
+            ProductBuilder::build,
+            AttributeDescriptor("id", Product::id, ProductBuilder::id::set, NumberValueConverters.Int),
+            AttributeDescriptor("name", Product::name, ProductBuilder::name::set, StringValueConverter),
+            AttributeDescriptor("in-stock", Product::inStock, ProductBuilder::inStock::set, BooleanValueConverter),
+            unknownValueHandling = UnknownValueHandling.ThrowException,
+        )
+
+        val item = itemOf(
+            "id" to 42,
+            "name" to "Foo 2.0",
+            "in-stock" to true,
+            "sneaky-unknown-attribute" to "😈",
+        )
+
+        assertFailsWith<IllegalArgumentException> { converter.convertLeft(item) }
+    }
+
+    @Test
+    fun testUnknownAttributesCustomHandler() {
+        data class UnknownAttribute(val name: String, val value: AttributeValue, val builder: ProductBuilder)
+        val unknownAttributes = mutableListOf<UnknownAttribute>()
+
+        val converter = SimpleItemConverter(
+            ::ProductBuilder,
+            ProductBuilder::build,
+            AttributeDescriptor("id", Product::id, ProductBuilder::id::set, NumberValueConverters.Int),
+            AttributeDescriptor("name", Product::name, ProductBuilder::name::set, StringValueConverter),
+            AttributeDescriptor("in-stock", Product::inStock, ProductBuilder::inStock::set, BooleanValueConverter),
+            unknownValueHandling = UnknownValueHandling.Custom { name, value, builder ->
+                unknownAttributes += UnknownAttribute(name, value, builder)
+            },
+        )
+
+        val item = itemOf(
+            "id" to 42,
+            "name" to "Foo 2.0",
+            "in-stock" to true,
+            "sneaky-unknown-attribute" to "😈",
+        )
+        val product = converter.convertLeft(item)
+
+        assertEquals(1, unknownAttributes.size)
+        val unknown = unknownAttributes.single()
+
+        assertEquals("sneaky-unknown-attribute", unknown.name)
+        assertEquals("😈", unknown.value.asS())
+        assertEquals(42, unknown.builder.id)
+        assertEquals("Foo 2.0", unknown.builder.name)
+        assertEquals(true, unknown.builder.inStock)
+
+        assertEquals(Product(42, "Foo 2.0", inStock = true), product)
     }
 }
 

--- a/hll/hll-codegen/src/main/kotlin/aws/sdk/kotlin/hll/codegen/core/CodeGeneratorFactory.kt
+++ b/hll/hll-codegen/src/main/kotlin/aws/sdk/kotlin/hll/codegen/core/CodeGeneratorFactory.kt
@@ -18,7 +18,7 @@ import com.google.devtools.ksp.processing.CodeGenerator as KSCodeGenerator
 public class CodeGeneratorFactory(
     private val ksCodeGenerator: KSCodeGenerator,
     private val logger: KSPLogger,
-    private val dependencies: Dependencies = Dependencies.ALL_FILES,
+    private val dependencies: Dependencies,
 ) {
     /**
      * Creates a new [CodeGenerator] backed by a [KSCodeGenerator]. The returned generator starts with no imports and

--- a/hll/hll-codegen/src/main/kotlin/aws/sdk/kotlin/hll/codegen/rendering/BuilderRenderer.kt
+++ b/hll/hll-codegen/src/main/kotlin/aws/sdk/kotlin/hll/codegen/rendering/BuilderRenderer.kt
@@ -121,7 +121,5 @@ public class BuilderRenderer(
             }
             blankLine()
         }
-
-        // TODO add DSL methods for low-level structure members
     }
 }


### PR DESCRIPTION
## Issue \#

Related to #472 

## Description of changes

This PR is a cleanup of various `TODO`s and `FIXME`s in DynamoDB Mapper's codebase. In particular:
* Provide options for handling unknown values in `SimpleItemConverter`. This will allow users to gracefully handle cases where items are not fully modeled in a schema.
* Properly map Condition Expressions to `FilterDsl`. This has the effect of adding a new `condition: BooleanExpr` property to `DeleteItemRequest`, `PutItemRequest`, and `UpdateItemRequest`, along with adding a new `condition(block: FilterDsl.() -> BooleanExpr?)` method to each of those requests' builders.
* Pass a proper list of file dependencies to KSP's `CodeGenerator` when creating new files for ops codegen. This will speed up build times by narrowing the set of dependency files to check before potentially regenerating DDB Mapper operation files.
* Removed various `FIXME`s and `TODO`s which are not planned to be implemented/addressed. Some of these were speculative or have become obsolete.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
