### PR TITLE
feat: implemented StaticRegionProvider class that always returns a static, pre-configured region.

### DIFF
--- a/.changes/6f3e5a1b-4c92-4d8a-bf7e-9a1c3d5e7f2b.json
+++ b/.changes/6f3e5a1b-4c92-4d8a-bf7e-9a1c3d5e7f2b.json
@@ -1,0 +1,8 @@
+{
+  "id": "6f3e5a1b-4c92-4d8a-bf7e-9a1c3d5e7f2b",
+  "type": "feature",
+  "description": "Add StaticRegionProvider for explicitly setting a region via RegionProvider",
+  "issues": [
+    "aws/aws-sdk-kotlin#1005"
+  ]
+}

--- a/aws-runtime/aws-config/api/aws-config.api
+++ b/aws-runtime/aws-config/api/aws-config.api
@@ -661,6 +661,11 @@ public final class aws/sdk/kotlin/runtime/region/ResolveRegionKt {
 	public static synthetic fun resolveSigV4aSigningRegionSet$default (Laws/smithy/kotlin/runtime/util/PlatformProvider;Laws/smithy/kotlin/runtime/util/LazyAsyncValue;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
+public final class aws/sdk/kotlin/runtime/region/StaticRegionProvider : aws/smithy/kotlin/runtime/client/region/RegionProvider {
+	public fun <init> (Ljava/lang/String;)V
+	public fun getRegion (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class aws/sdk/kotlin/runtime/region/ValidateRegionKt {
 	public static final fun isRegionValid (Ljava/lang/String;)Z
 	public static final fun validateRegion (Ljava/lang/String;)Ljava/lang/String;

--- a/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/region/StaticRegionProvider.kt
+++ b/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/region/StaticRegionProvider.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.sdk.kotlin.runtime.region
+
+import aws.smithy.kotlin.runtime.client.region.RegionProvider
+
+/**
+ * [RegionProvider] that always returns a static, pre-configured region.
+ */
+public class StaticRegionProvider(private val region: String) : RegionProvider {
+    override suspend fun getRegion(): String = region
+}

--- a/aws-runtime/aws-config/common/test/aws/sdk/kotlin/runtime/region/StaticRegionProviderTest.kt
+++ b/aws-runtime/aws-config/common/test/aws/sdk/kotlin/runtime/region/StaticRegionProviderTest.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.sdk.kotlin.runtime.region
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StaticRegionProviderTest {
+    @Test
+    fun providesRegion() = runTest {
+        val provider = StaticRegionProvider("us-west-2")
+        assertEquals("us-west-2", provider.getRegion())
+    }
+
+    @Test
+    fun providesCustomRegion() = runTest {
+        val provider = StaticRegionProvider("eu-central-1")
+        assertEquals("eu-central-1", provider.getRegion())
+    }
+}


### PR DESCRIPTION
## Issue \#
#1005 

## Description of changes
Implemented `StaticRegionProvider` class that always returns a static, pre-configured region. This is useful for cases where users build custom RegionProviderChain instances and need a composable building block for explicitly-set regions (e.g., development environments where region can't be inferred from the environment)

**NOTE:**
- Region validation is done in the generated client; e.g. from generated `S3Client.kt`:
  ```Kotlin
  override val region: String? = (builder.region ?: runBlocking { builder.regionProvider?.getRegion() ?: resolveRegion() })?.let { validateRegion(it) }
  ```
- `StaticRegionProvider` is not registered in the list of providers in `aws-runtime\aws-config\jvm\src\aws\sdk\kotlin\runtime\region\DefaultRegionProviderChainJVM.kt`. The reason is that `DefaultRegionProviderChain` is meant for auto-detecting region from the environment (e.g. system props, env vars, profile, IMDS). A static provider doesn't fit that chain because it requires a user-supplied value at construction time and would always "win" if placed first, making the other providers pointless. This will be used by users who build their own `RegionProviderChain` and want a `StaticRegionProvider` as one of the composable building blocks, so this is not about modifying the default chain.

___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
