### PR TITLE
fix: unblock Signin minimal client from building

### DIFF
--- a/aws-runtime/aws-config/build.gradle.kts
+++ b/aws-runtime/aws-config/build.gradle.kts
@@ -213,13 +213,16 @@ smithyBuild {
                 }
             }
 
+            // FIXME `IntrospectOAuth2TokenWithIAM` is not needed for any credentials provider and is only added because
+            //  of https://github.com/smithy-lang/smithy/issues/3190
             transforms = listOf(
                 """
             {
                 "name": "awsSmithyKotlinIncludeOperations",
                 "args": {
                     "operations": [
-                        "com.amazonaws.signin#CreateOAuth2Token"
+                        "com.amazonaws.signin#CreateOAuth2Token",
+                        "com.amazonaws.signin#IntrospectOAuth2TokenWithIAM"
                     ]
                 }
             }


### PR DESCRIPTION
## Issue \#

Workaround for https://github.com/smithy-lang/smithy/issues/3190

## Description of changes

This change adds a dummy operation to the minimal `SigninClient` generated for `LoginCredentialsProvider`. This is necessary because an upcoming model change adds new endpoint ruleset parameters but the minimal client removes all operations which reference them, causing a failure during Smithy validation as part of codegen. This change can be reverted when https://github.com/smithy-lang/smithy/issues/3190 is resolved.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
