### PR TITLE
fix: update operation included in Signin minimal client to workaround Smithy validator bug

### DIFF
--- a/aws-runtime/aws-config/build.gradle.kts
+++ b/aws-runtime/aws-config/build.gradle.kts
@@ -213,7 +213,7 @@ smithyBuild {
                 }
             }
 
-            // FIXME `IntrospectOAuth2TokenWithIAM` is not needed for any credentials provider and is only added because
+            // FIXME `CreateOauth2TokenWithIAM` is not needed for any credentials provider and is only added because
             //  of https://github.com/smithy-lang/smithy/issues/3190
             transforms = listOf(
                 """
@@ -222,7 +222,7 @@ smithyBuild {
                 "args": {
                     "operations": [
                         "com.amazonaws.signin#CreateOAuth2Token",
-                        "com.amazonaws.signin#IntrospectOAuth2TokenWithIAM"
+                        "com.amazonaws.signin#CreateOauth2TokenWithIAM"
                     ]
                 }
             }


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Update of https://github.com/aws/aws-sdk-kotlin/pull/1932. The Signin model has been changed again and no longer includes the `IsOAuthEndpoint` parameter in `IntrospectOAuth2TokenWithIAM`. The only remaining operation with this parameter is `CreateOauth2TokenWithIAM`, which is now included in the minimal client to workaround [the Smithy validator bug on trimmed models](https://github.com/smithy-lang/smithy/issues/3190).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
