### PR TITLE
chore: run the main→release merge workflow every day, not just every weekday

### DIFF
--- a/.github/workflows/update-release-branch.yml
+++ b/.github/workflows/update-release-branch.yml
@@ -14,7 +14,7 @@ on:
         type: boolean
         default: false
   schedule:
-    - cron: "0 7 * * 1-5"  # At 07:00 UTC (00:00 PST, 03:00 EST), Monday through Friday
+    - cron: "0 7 * * *"  # Every day at 07:00 UTC (00:00 Pacific Time, 03:00 Eastern Time)
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Updates our **main**→**release** merge workflow to happen all 7 days/week instead of only weekdays.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
