### PR TITLE
feat: add logRedactedHeaders support for sanitizing sensitive headers in debug logging

### DIFF
--- a/.changes/ce77d728-ae6c-422e-8e75-17ea1ac82c88.json
+++ b/.changes/ce77d728-ae6c-422e-8e75-17ea1ac82c88.json
@@ -1,0 +1,9 @@
+{
+  "id": "ce77d728-ae6c-422e-8e75-17ea1ac82c88",
+  "type": "feature",
+  "description": "Add support for `logRedactedHeaders` client config property to sanitize sensitive header values in debug logging",
+  "issues": [
+    "#1460"
+  ],
+  "module": "aws-config"
+}

--- a/aws-runtime/aws-config/api/aws-config.api
+++ b/aws-runtime/aws-config/api/aws-config.api
@@ -292,6 +292,10 @@ public abstract interface class aws/sdk/kotlin/runtime/config/AwsSdkClientConfig
 	public abstract fun setUseFips (Ljava/lang/Boolean;)V
 }
 
+public final class aws/sdk/kotlin/runtime/config/AwsSdkClientConfig$DefaultImpls {
+	public static fun getLogRedactedHeaders (Laws/sdk/kotlin/runtime/config/AwsSdkClientConfig;)Ljava/util/Set;
+}
+
 public final class aws/sdk/kotlin/runtime/config/AwsSdkClientOption {
 	public static final field INSTANCE Laws/sdk/kotlin/runtime/config/AwsSdkClientOption;
 	public final fun getApplicationId ()Laws/smithy/kotlin/runtime/collections/AttributeKey;

--- a/aws-runtime/aws-config/api/aws-config.api
+++ b/aws-runtime/aws-config/api/aws-config.api
@@ -292,10 +292,6 @@ public abstract interface class aws/sdk/kotlin/runtime/config/AwsSdkClientConfig
 	public abstract fun setUseFips (Ljava/lang/Boolean;)V
 }
 
-public final class aws/sdk/kotlin/runtime/config/AwsSdkClientConfig$DefaultImpls {
-	public static fun getLogRedactedHeaders (Laws/sdk/kotlin/runtime/config/AwsSdkClientConfig;)Ljava/util/Set;
-}
-
 public final class aws/sdk/kotlin/runtime/config/AwsSdkClientOption {
 	public static final field INSTANCE Laws/sdk/kotlin/runtime/config/AwsSdkClientOption;
 	public final fun getApplicationId ()Laws/smithy/kotlin/runtime/collections/AttributeKey;

--- a/aws-runtime/aws-config/jvm/test/aws/sdk/kotlin/runtime/config/AbstractAwsSdkClientFactoryTest.kt
+++ b/aws-runtime/aws-config/jvm/test/aws/sdk/kotlin/runtime/config/AbstractAwsSdkClientFactoryTest.kt
@@ -125,6 +125,7 @@ private interface TestClient : SdkClient {
         RetryStrategyClientConfig by builder.buildRetryStrategyClientConfig() {
         override val clientName: String = builder.clientName
         override val logMode: LogMode = builder.logMode ?: LogMode.Default
+        override val logRedactedHeaders: Set<String> = builder.logRedactedHeaders ?: emptySet()
         override val region: String? = builder.region
         override var regionProvider: RegionProvider = builder.regionProvider ?: DefaultRegionProviderChain()
         override var useFips: Boolean = builder.useFips ?: false
@@ -138,6 +139,7 @@ private interface TestClient : SdkClient {
             RetryStrategyClientConfig.Builder by RetryStrategyClientConfigImpl.BuilderImpl() {
             override var clientName: String = "Test"
             override var logMode: LogMode? = LogMode.Default
+            override var logRedactedHeaders: Set<String>? = null
             override var region: String? = null
             override var regionProvider: RegionProvider? = null
             override var useFips: Boolean? = null

--- a/aws-runtime/aws-config/jvm/test/aws/sdk/kotlin/runtime/config/AbstractAwsSdkClientFactoryTest.kt
+++ b/aws-runtime/aws-config/jvm/test/aws/sdk/kotlin/runtime/config/AbstractAwsSdkClientFactoryTest.kt
@@ -122,10 +122,11 @@ private interface TestClient : SdkClient {
     class Config private constructor(builder: Builder) :
         SdkClientConfig,
         AwsSdkClientConfig,
+        LogRedactionConfig,
         RetryStrategyClientConfig by builder.buildRetryStrategyClientConfig() {
         override val clientName: String = builder.clientName
         override val logMode: LogMode = builder.logMode ?: LogMode.Default
-        override val logRedactedHeaders: Set<String> = builder.logRedactedHeaders ?: emptySet()
+        override val logRedactedHeaders: Set<String> = builder.logRedactedHeaders
         override val region: String? = builder.region
         override var regionProvider: RegionProvider = builder.regionProvider ?: DefaultRegionProviderChain()
         override var useFips: Boolean = builder.useFips ?: false
@@ -135,11 +136,12 @@ private interface TestClient : SdkClient {
         // new: inherits builder equivalents for Config base classes
         class Builder :
             AwsSdkClientConfig.Builder,
+            LogRedactionConfig.Builder,
             SdkClientConfig.Builder<Config>,
             RetryStrategyClientConfig.Builder by RetryStrategyClientConfigImpl.BuilderImpl() {
             override var clientName: String = "Test"
             override var logMode: LogMode? = LogMode.Default
-            override var logRedactedHeaders: Set<String>? = null
+            override var logRedactedHeaders: MutableSet<String> = mutableSetOf()
             override var region: String? = null
             override var regionProvider: RegionProvider? = null
             override var useFips: Boolean? = null

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ atomicfu-version = "0.33.0"
 binary-compatibility-validator-version = "0.18.1"
 
 # smithy-kotlin
-smithy-kotlin-version = "1.7.0"
+smithy-kotlin-version = "1.7.1"
 
 # codegen
 smithy-version = "1.71.0"


### PR DESCRIPTION
## Issue \#
#1460 

## Description of changes
Added `logRedactedHeaders` support for sanitizing sensitive headers in debug logging.

The main change is in https://github.com/smithy-lang/smithy-kotlin repo via PR https://github.com/smithy-lang/smithy-kotlin/pull/1640
___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
