### PR TITLE
fix: correct the operation name used to allowlist IsOAuthEndpoint ruleset param yet again

### DIFF
--- a/aws-runtime/aws-config/build.gradle.kts
+++ b/aws-runtime/aws-config/build.gradle.kts
@@ -222,7 +222,7 @@ smithyBuild {
                 "args": {
                     "operations": [
                         "com.amazonaws.signin#CreateOAuth2Token",
-                        "com.amazonaws.signin#CreateOauth2TokenWithIAM"
+                        "com.amazonaws.signin#CreateOAuth2TokenWithIAM"
                     ]
                 }
             }


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

The Signin operation name used to allowlist the `IsOAuthEndpoint` ruleset param has changed again—this time from `CreateOauth2TokenWithIAM` to `CreateOAuth2TokenWithIAM` (note that `Auth` is now capitalized according to PascalCase rules).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
