### PR TITLE
chore: update smithy-kotlin to v1.7.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ atomicfu-version = "0.33.0"
 binary-compatibility-validator-version = "0.18.1"
 
 # smithy-kotlin
-smithy-kotlin-version = "1.7.1"
+smithy-kotlin-version = "1.7.2"
 
 # codegen
 smithy-version = "1.71.0"


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Bump **smithy-kotlin** to [**v1.7.2**](https://github.com/smithy-lang/smithy-kotlin/releases/tag/v1.7.2) to incorporate [codegen bugfix for floating point literals](https://github.com/smithy-lang/smithy-kotlin/pull/1642).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
