### PR TITLE
add auto-mapping support for `Set<ByteArray>`

### DIFF
--- a/hll/ddb-mapper/dynamodb-mapper-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/model/MapperTypes.kt
+++ b/hll/ddb-mapper/dynamodb-mapper-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/model/MapperTypes.kt
@@ -328,6 +328,7 @@ public object MapperTypes {
             public val StringSetValueConverter: TypeRef = TypeRef(MapperPkg.Hl.CollectionValues, "StringSetValueConverter")
             public val CharSetValueConverter: TypeRef = TypeRef(MapperPkg.Hl.CollectionValues, "CharSetValueConverter")
             public val CharArraySetValueConverter: TypeRef = TypeRef(MapperPkg.Hl.CollectionValues, "CharArraySetValueConverter")
+            public val ByteArraySetValueConverter: TypeRef = TypeRef(MapperPkg.Hl.CollectionValues, "ByteArraySetValueConverter")
 
             public val ByteSetValueConverter: TypeRef = TypeRef(MapperPkg.Hl.CollectionValues, "NumberSetValueConverters.Byte")
             public val DoubleSetValueConverter: TypeRef = TypeRef(MapperPkg.Hl.CollectionValues, "NumberSetValueConverters.Double")

--- a/hll/ddb-mapper/dynamodb-mapper-schema-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/annotations/rendering/SchemaRenderer.kt
+++ b/hll/ddb-mapper/dynamodb-mapper-schema-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/annotations/rendering/SchemaRenderer.kt
@@ -308,6 +308,7 @@ internal class SchemaRenderer(
     private val KSType.setValueConverter: Type
         get() = when (Type.from(this)) {
             Types.Kotlin.String -> MapperTypes.Values.Collections.StringSetValueConverter
+            Types.Kotlin.ByteArray -> MapperTypes.Values.Collections.ByteArraySetValueConverter
             Types.Kotlin.Char -> MapperTypes.Values.Collections.CharSetValueConverter
             Types.Kotlin.CharArray -> MapperTypes.Values.Collections.CharArraySetValueConverter
             Types.Kotlin.Byte -> MapperTypes.Values.Collections.ByteSetValueConverter

--- a/hll/ddb-mapper/dynamodb-mapper-schema-generator-plugin/src/test/resources/standard-item-converters/src/Sets.kt
+++ b/hll/ddb-mapper/dynamodb-mapper-schema-generator-plugin/src/test/resources/standard-item-converters/src/Sets.kt
@@ -15,6 +15,7 @@ public data class Sets(
      * Sets
      */
     var setString: Set<String>,
+    var setByteArray: Set<ByteArray>,
     var setCharArray: Set<CharArray>,
     var setChar: Set<Char>,
     var setByte: Set<Byte>,
@@ -36,6 +37,7 @@ public data class Sets(
 
         if (id != other.id) return false
         if (setString != other.setString) return false
+        if (!setByteArray.all { thisArray -> other.setByteArray.any { otherArray -> thisArray.contentEquals(otherArray) } }) return false
         if (setCharArray.size != other.setCharArray.size) return false
         if (!setCharArray.all { thisArray -> other.setCharArray.any { otherArray -> thisArray.contentEquals(otherArray) } }) return false
         if (setChar != other.setChar) return false

--- a/hll/ddb-mapper/dynamodb-mapper-schema-generator-plugin/src/test/resources/standard-item-converters/test/SetsTest.kt
+++ b/hll/ddb-mapper/dynamodb-mapper-schema-generator-plugin/src/test/resources/standard-item-converters/test/SetsTest.kt
@@ -14,6 +14,7 @@ public class SetsTest {
         val sets = Sets(
             id = 1,
             setString = setOf("one", "two", "three"),
+            setByteArray = setOf(byteArrayOf(1, 2, 3), byteArrayOf(4, 5, 6)),
             setCharArray = setOf(charArrayOf('a', 'b'), charArrayOf('c', 'd')),
             setChar = setOf('x', 'y', 'z'),
             setByte = setOf(10, 20, 30),

--- a/hll/ddb-mapper/dynamodb-mapper/api/dynamodb-mapper.api
+++ b/hll/ddb-mapper/dynamodb-mapper/api/dynamodb-mapper.api
@@ -3079,8 +3079,8 @@ public final class aws/sdk/kotlin/hll/dynamodbmapper/values/collections/Attribut
 	public fun convertRight (Ljava/util/Map;)Laws/sdk/kotlin/services/dynamodb/model/AttributeValue;
 }
 
-public final class aws/sdk/kotlin/hll/dynamodbmapper/values/collections/ByteArraySetConverter : aws/sdk/kotlin/hll/mapping/core/converters/Converter {
-	public static final field INSTANCE Laws/sdk/kotlin/hll/dynamodbmapper/values/collections/ByteArraySetConverter;
+public final class aws/sdk/kotlin/hll/dynamodbmapper/values/collections/ByteArraySetValueConverter : aws/sdk/kotlin/hll/mapping/core/converters/Converter {
+	public static final field INSTANCE Laws/sdk/kotlin/hll/dynamodbmapper/values/collections/ByteArraySetValueConverter;
 	public fun convertLeft (Laws/sdk/kotlin/services/dynamodb/model/AttributeValue;)Ljava/util/Set;
 	public synthetic fun convertLeft (Ljava/lang/Object;)Ljava/lang/Object;
 	public synthetic fun convertRight (Ljava/lang/Object;)Ljava/lang/Object;

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/collections/PrimitiveSetValueConverters.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/collections/PrimitiveSetValueConverters.kt
@@ -15,7 +15,7 @@ import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
  * Converts between a [Set] of [ByteArray] elements and
  * [DynamoDB `BS` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.SetTypes)
  */
-public object ByteArraySetConverter : ValueConverter<Set<ByteArray>> {
+public object ByteArraySetValueConverter : ValueConverter<Set<ByteArray>> {
     override fun convertLeft(from: AttributeValue): Set<ByteArray> = from.asBs().toSet()
     override fun convertRight(from: Set<ByteArray>): AttributeValue = AttributeValue.Bs(from.toList())
 }

--- a/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/values/collections/SetValueConvertersTest.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/test/aws/sdk/kotlin/hll/dynamodbmapper/values/collections/SetValueConvertersTest.kt
@@ -12,7 +12,7 @@ private val emptyNumberSet = AttributeValue.Ns(listOf())
 
 class SetValueConvertersTest : ValueConvertersTest() {
     @Test
-    fun testByteArraySetConverter() = given(ByteArraySetConverter) {
+    fun testByteArraySetConverter() = given(ByteArraySetValueConverter) {
         setOf(byteArrayOf(1, 1, 2, 3), byteArrayOf(5, 8), byteArrayOf(13, 21, 34, 55, 89)) inDdbIs theSame
         setOf<ByteArray>() inDdbIs AttributeValue.Bs(listOf())
     }


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Adds missing support for automatically mapping `Set<ByteArray>` to a value converter for DynamoDB Mapper.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
