### PR TITLE
add JvmName import

### DIFF
--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/FilterDsl.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/FilterDsl.kt
@@ -5,6 +5,7 @@
 package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 
 import aws.sdk.kotlin.hll.dynamodbmapper.util.dynamicAv
+import kotlin.jvm.JvmName
 
 /**
  * A DSL interface providing support for "low-level"

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/LiteralExpr.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/LiteralExpr.kt
@@ -7,6 +7,7 @@ package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.LiteralExprImpl
 import aws.sdk.kotlin.hll.dynamodbmapper.util.av
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
+import kotlin.jvm.JvmName
 
 /**
  * Represents an expression that consists of a single literal value

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/SortKeyFilterDsl.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/SortKeyFilterDsl.kt
@@ -4,6 +4,8 @@
  */
 package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 
+import kotlin.jvm.JvmName
+
 /**
  * Represents a sort key independent of schema
  */

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateDsl.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/UpdateDsl.kt
@@ -5,6 +5,7 @@
 package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 
 import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
+import kotlin.jvm.JvmName
 
 /**
  * A DSL interface providing support for creating "low-level"

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/KeyConversion.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/KeyConversion.kt
@@ -6,6 +6,7 @@ package aws.sdk.kotlin.hll.dynamodbmapper.items
 
 import aws.sdk.kotlin.hll.dynamodbmapper.model.Item
 import aws.sdk.kotlin.hll.dynamodbmapper.model.toItem
+import kotlin.jvm.JvmName
 
 /**
  * Converts the given partition key to an [Item] with the given schema

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/model/Item.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/model/Item.kt
@@ -7,6 +7,7 @@ package aws.sdk.kotlin.hll.dynamodbmapper.model
 import aws.sdk.kotlin.hll.dynamodbmapper.model.internal.ItemImpl
 import aws.sdk.kotlin.hll.dynamodbmapper.util.dynamicAv
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
+import kotlin.jvm.JvmName
 
 /**
  * An immutable representation of a low-level item in a DynamoDB table. Items consist of attributes, each of which have

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/util/AttributeValues.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/util/AttributeValues.kt
@@ -5,6 +5,7 @@
 package aws.sdk.kotlin.hll.dynamodbmapper.util
 
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
+import kotlin.jvm.JvmName
 
 internal val NULL_ATTR = AttributeValue.Null(true)
 

--- a/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/collections/MapValueConverter.kt
+++ b/hll/ddb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/collections/MapValueConverter.kt
@@ -9,6 +9,7 @@ import aws.sdk.kotlin.hll.mapping.core.converters.Converter
 import aws.sdk.kotlin.hll.mapping.core.converters.ConverterChain
 import aws.sdk.kotlin.hll.mapping.core.converters.collections.MapMappingConverter
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
+import kotlin.jvm.JvmName
 
 /**
  * Converts between [Map] and


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
jsonName is auto imported for JVM, but not for `common` platform

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
