### PR TITLE
chore: version bump smithy-kotlin-version to 1.7.6

### DIFF
--- a/.changes/2aef6767-a5dc-4853-876e-4da92a739254.json
+++ b/.changes/2aef6767-a5dc-4853-876e-4da92a739254.json
@@ -1,0 +1,8 @@
+{
+    "id": "2aef6767-a5dc-4853-876e-4da92a739254",
+    "type": "feature",
+    "description": "Bump **smithy-kotlin** version to [**v1.7.6**](https://github.com/smithy-lang/smithy-kotlin/releases/tag/v1.7.6) to pick up support for EMF telemetry provider",
+    "issues": [
+        "#1638"
+    ]
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ atomicfu-version = "0.33.0"
 binary-compatibility-validator-version = "0.18.1"
 
 # smithy-kotlin
-smithy-kotlin-version = "1.7.4"
+smithy-kotlin-version = "1.7.6"
 
 # codegen
 smithy-version = "1.72.1"


### PR DESCRIPTION
## Issue \#
#1638

## Description of changes
Version bump `smithy-kotlin-version` to `1.7.6` that contains changes for new [telemetry-provider-emf](https://central.sonatype.com/artifact/aws.smithy.kotlin/telemetry-provider-emf) package.
___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
