### PR TITLE
fix: support "provided" classpath handling for deploying the DynamoDB Mapper schema generator plugin in non-Gradle environments

### DIFF
--- a/hll/ddb-mapper/dynamodb-mapper-schema-generator-plugin/build.gradle.kts
+++ b/hll/ddb-mapper/dynamodb-mapper-schema-generator-plugin/build.gradle.kts
@@ -94,6 +94,62 @@ tasks.test {
 val sdkVersion: String by project
 
 /**
+ * Strategy the generated plugin uses to place the schema-codegen KSP processor on a consumer's `ksp`
+ * configuration. The value is fixed here, at *this plugin's* build time (not the consumer's build), and baked
+ * into a generated `PROCESSOR_CLASSPATH_MODE` constant that [SchemaGeneratorPlugin] switches on:
+ *
+ *  - `resolved` (default): declare a Maven coordinate for the processor and let the consumer's build resolve it
+ *    from a repository. This is the behavior for repository-published builds.
+ *  - `provided`: the surrounding build environment supplies the processor and its full dependency closure on the
+ *    plugin's own runtime classpath; the plugin injects those files directly instead of resolving a coordinate.
+ *    Use this when the consumer build has no repository able to resolve the processor coordinate/closure.
+ *
+ * Controlled by the `aws.dynamodbmapper.schema.processor_classpath` Gradle property.
+ */
+val processorClasspathMode = (findProperty("aws.dynamodbmapper.schema.processor_classpath") as? String)?.lowercase() ?: "resolved"
+require(processorClasspathMode == "resolved" || processorClasspathMode == "provided") {
+    "Invalid value '$processorClasspathMode' for the `aws.dynamodbmapper.schema.processor_classpath` property; expected 'resolved' or 'provided'."
+}
+
+/**
+ * Generate a source constant recording [processorClasspathMode] so it is compiled into the published plugin jar
+ * and available to [SchemaGeneratorPlugin] at the consumer's build time.
+ */
+val generateProcessorClasspathMode by tasks.registering {
+    val outputDir = layout.buildDirectory.dir("generated/sources/processorClasspathMode/kotlin")
+    inputs.property("mode", processorClasspathMode)
+    outputs.dir(outputDir)
+    doLast {
+        val file = outputDir.get()
+            .file("aws/sdk/kotlin/hll/dynamodbmapper/plugins/ProcessorClasspathMode.kt")
+            .asFile
+        file.parentFile.mkdirs()
+        file.writeText(
+            """
+            |/*
+            | * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+            | * SPDX-License-Identifier: Apache-2.0
+            | */
+            |package aws.sdk.kotlin.hll.dynamodbmapper.plugins
+            |
+            |// Generated at build time from the `aws.dynamodbmapper.schema.processor_classpath` Gradle property.
+            |// Do not edit by hand.
+            |internal const val PROCESSOR_CLASSPATH_MODE: String = "$processorClasspathMode"
+            |
+            """.trimMargin(),
+        )
+    }
+}
+
+kotlin {
+    sourceSets.named("main") {
+        // Passing the task provider registers the generated dir as "built by" the task, so every consumer
+        // (compileKotlin, sourcesJar, ktlint, ...) inherits the dependency without a separate `dependsOn`.
+        kotlin.srcDir(generateProcessorClasspathMode)
+    }
+}
+
+/**
  * Create a file containing the sdkVersion to use as a resource
  * This saves us from having to manually change version numbers in multiple places
  */

--- a/hll/ddb-mapper/dynamodb-mapper-schema-generator-plugin/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/plugins/SchemaGeneratorPlugin.kt
+++ b/hll/ddb-mapper/dynamodb-mapper-schema-generator-plugin/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/plugins/SchemaGeneratorPlugin.kt
@@ -11,6 +11,9 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.create
+import java.io.File
+import java.net.URL
+import java.net.URLClassLoader
 
 public class SchemaGeneratorPlugin : Plugin<Project> {
     override fun apply(project: Project): Unit = project.run {
@@ -37,10 +40,89 @@ public class SchemaGeneratorPlugin : Plugin<Project> {
             excludeProcessor("aws.sdk.kotlin.hll.dynamodbmapper.codegen.operations.HighLevelOpsProcessorProvider")
         }
 
-        val sdkVersion = getSdkVersion()
-        dependencies.add("ksp", "aws.sdk.kotlin:dynamodb-mapper-schema-codegen:$sdkVersion")
+        when (PROCESSOR_CLASSPATH_MODE) {
+            "provided" -> {
+                // The surrounding build environment has already placed the schema-codegen processor and its full
+                // dependency closure on this plugin's runtime classpath. Inject those files directly instead of
+                // declaring a coordinate, since no repository able to resolve the coordinate/closure is available.
+                dependencies.add("ksp", files(resolveProvidedProcessorClasspath()))
+            }
+            else -> {
+                // Declare a coordinate for the processor and let the consumer's build resolve it from a repository.
+                val sdkVersion = getSdkVersion()
+                dependencies.add("ksp", "aws.sdk.kotlin:dynamodb-mapper-schema-codegen:$sdkVersion")
+            }
+        }
     }
 
     // Reads sdk-version.txt for the SDK version to add dependencies on. The file is created in this module's build.gradle.kts
     private fun getSdkVersion(): String = checkNotNull(this::class.java.getResource("sdk-version.txt")?.readText()) { "Could not read sdk-version.txt" }
+
+    /**
+     * Collects the schema-codegen KSP processor and its dependency closure from this plugin's own runtime
+     * classpath. Used when [PROCESSOR_CLASSPATH_MODE] is `provided`: the surrounding build environment supplies
+     * these files on the plugin class loader, so they can be added to the `ksp` configuration directly without
+     * repository resolution.
+     */
+    private fun resolveProvidedProcessorClasspath(): List<File> {
+        val classLoader = javaClass.classLoader
+        val urls = (classLoader as? URLClassLoader)?.urLs
+            ?: error(
+                "Cannot supply the schema-generation processor classpath: the plugin class loader " +
+                    "(${classLoader::class.java.name}) does not expose its URLs. The `provided` processor classpath " +
+                    "mode requires an environment that places the processor on the plugin's runtime classpath.",
+            )
+
+        val candidates = urls.mapNotNull { it.toFileOrNull() }
+        val selfLocation = SchemaGeneratorPlugin::class.java.protectionDomain?.codeSource?.location?.toFileOrNull()
+
+        // Anchor on a class that only exists in the schema-codegen artifact, to guarantee the processor's own jar
+        // is present even if the class loader layout is unusual.
+        val anchor = runCatching {
+            Class.forName("aws.sdk.kotlin.hll.dynamodbmapper.codegen.annotations.AnnotationsProcessorProvider")
+                .protectionDomain?.codeSource?.location
+        }.getOrNull()?.toFileOrNull()
+
+        return selectProvidedProcessorClasspath(candidates, selfLocation, anchor)
+    }
+}
+
+private fun URL.toFileOrNull(): File? = runCatching { File(toURI()) }.getOrNull()
+
+/**
+ * Artifacts present on the plugin's runtime classpath purely for Gradle wiring; they must not leak onto the KSP
+ * processor classpath, where they are unnecessary and can conflict with the Kotlin compiler.
+ */
+private val PROCESSOR_CLASSPATH_EXCLUSIONS = listOf(
+    "kotlin-gradle-plugin",
+    "symbol-processing-gradle-plugin",
+    "gradle-api",
+    "gradle-kotlin-dsl",
+    "kotlin-compiler-embeddable",
+)
+
+/**
+ * Selects the KSP processor classpath from [candidates] (the plugin's own runtime classpath): drops the plugin's
+ * own artifact ([selfLocation]) and the Gradle/KGP/KSP-Gradle wiring artifacts in [PROCESSOR_CLASSPATH_EXCLUSIONS],
+ * and guarantees the processor's own artifact ([anchor]) is present.
+ *
+ * Kept pure and side-effect free so it can be unit tested without a Gradle project or class loader.
+ */
+internal fun selectProvidedProcessorClasspath(
+    candidates: List<File>,
+    selfLocation: File?,
+    anchor: File?,
+): List<File> {
+    val files = candidates
+        .asSequence()
+        .filter { it != selfLocation }
+        .filter { file -> PROCESSOR_CLASSPATH_EXCLUSIONS.none { file.name.contains(it, ignoreCase = true) } }
+        .toMutableList()
+
+    if (anchor != null && anchor !in files) files.add(anchor)
+
+    check(files.isNotEmpty()) {
+        "Resolved an empty schema-generation processor classpath from the plugin runtime classpath."
+    }
+    return files
 }

--- a/hll/ddb-mapper/dynamodb-mapper-schema-generator-plugin/src/test/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/plugins/ProvidedProcessorClasspathTest.kt
+++ b/hll/ddb-mapper/dynamodb-mapper-schema-generator-plugin/src/test/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/plugins/ProvidedProcessorClasspathTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.sdk.kotlin.hll.dynamodbmapper.plugins
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+
+/**
+ * Unit tests for [selectProvidedProcessorClasspath], the pure classpath-selection logic used by the plugin's
+ * `provided` processor-classpath mode. These exercise the filtering rules directly, without a Gradle project or
+ * class loader.
+ */
+class ProvidedProcessorClasspathTest {
+    private fun jar(name: String) = File("/deps/$name")
+
+    // Processor closure (should be kept)
+    private val schemaCodegen = jar("dynamodb-mapper-schema-codegen-1.5.0.jar")
+    private val hllCodegen = jar("hll-codegen-1.5.0.jar")
+    private val mapper = jar("dynamodb-mapper-1.5.0.jar")
+    private val smithyRuntime = jar("runtime-core-jvm-1.4.0.jar")
+
+    // Gradle wiring / the plugin itself (should be dropped)
+    private val pluginJar = jar("dynamodb-mapper-schema-generator-plugin-1.5.0.jar")
+    private val kotlinGradlePlugin = jar("kotlin-gradle-plugin-2.0.20.jar")
+    private val kspGradlePlugin = jar("symbol-processing-gradle-plugin-2.0.20-1.0.25.jar")
+    private val gradleApi = jar("gradle-api-9.6.1.jar")
+    private val gradleKotlinDsl = jar("gradle-kotlin-dsl-9.6.1.jar")
+    private val kotlinCompiler = jar("kotlin-compiler-embeddable-2.0.20.jar")
+
+    @Test
+    fun keepsProcessorClosureAndDropsGradleWiring() {
+        val candidates = listOf(
+            schemaCodegen, hllCodegen, mapper, smithyRuntime,
+            pluginJar, kotlinGradlePlugin, kspGradlePlugin, gradleApi, gradleKotlinDsl, kotlinCompiler,
+        )
+
+        val result = selectProvidedProcessorClasspath(candidates, selfLocation = pluginJar, anchor = schemaCodegen)
+
+        // Processor closure retained
+        assertContains(result, schemaCodegen)
+        assertContains(result, hllCodegen)
+        assertContains(result, mapper)
+        assertContains(result, smithyRuntime)
+
+        // Plugin's own jar and Gradle wiring removed
+        assertFalse(pluginJar in result, "the plugin's own artifact must not be on the processor classpath")
+        assertFalse(kotlinGradlePlugin in result)
+        assertFalse(kspGradlePlugin in result)
+        assertFalse(gradleApi in result)
+        assertFalse(gradleKotlinDsl in result)
+        assertFalse(kotlinCompiler in result)
+    }
+
+    @Test
+    fun addsAnchorWhenAbsentFromCandidates() {
+        val result = selectProvidedProcessorClasspath(
+            candidates = listOf(hllCodegen, mapper),
+            selfLocation = null,
+            anchor = schemaCodegen,
+        )
+        assertContains(result, schemaCodegen)
+    }
+
+    @Test
+    fun doesNotDuplicateAnchorWhenAlreadyPresent() {
+        val result = selectProvidedProcessorClasspath(
+            candidates = listOf(schemaCodegen, hllCodegen),
+            selfLocation = null,
+            anchor = schemaCodegen,
+        )
+        assertEquals(1, result.count { it == schemaCodegen })
+    }
+
+    @Test
+    fun exclusionMatchingIsCaseInsensitive() {
+        val mixedCaseKgp = jar("Kotlin-Gradle-Plugin-2.0.20.jar")
+        val result = selectProvidedProcessorClasspath(
+            candidates = listOf(schemaCodegen, mixedCaseKgp),
+            selfLocation = null,
+            anchor = null,
+        )
+        assertFalse(mixedCaseKgp in result)
+        assertContains(result, schemaCodegen)
+    }
+
+    @Test
+    fun throwsWhenNoCandidates() {
+        assertFailsWith<IllegalStateException> {
+            selectProvidedProcessorClasspath(candidates = emptyList(), selfLocation = null, anchor = null)
+        }
+    }
+
+    @Test
+    fun throwsWhenEverythingFilteredAndNoAnchor() {
+        assertFailsWith<IllegalStateException> {
+            selectProvidedProcessorClasspath(
+                candidates = listOf(kotlinGradlePlugin, gradleApi),
+                selfLocation = null,
+                anchor = null,
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

This change provides an alternative KSP dependency resolution mechanism for deploying the DynamoDB Mapper schema generator plugin in non-Gradle environments. Selection of the dependency model is handled by a new Gradle property `aws.dynamodbmapper.schema.processor_classpath`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
