### PR TITLE
fix: remove experimental annotation from telemetry interfaces/types

### DIFF
--- a/.changes/57d70ed1-0e4c-4afa-a020-c744cda74543.json
+++ b/.changes/57d70ed1-0e4c-4afa-a020-c744cda74543.json
@@ -1,0 +1,5 @@
+{
+    "id": "57d70ed1-0e4c-4afa-a020-c744cda74543",
+    "type": "bugfix",
+    "description": "`TelemetryProvider` and related types are no longer experimental"
+}

--- a/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/config/AbstractAwsSdkClientFactory.kt
+++ b/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/config/AbstractAwsSdkClientFactory.kt
@@ -20,7 +20,6 @@ import aws.sdk.kotlin.runtime.config.retries.resolveRetryConfig
 import aws.sdk.kotlin.runtime.config.useragent.resolveUserAgentAppId
 import aws.sdk.kotlin.runtime.region.resolveRegion
 import aws.sdk.kotlin.runtime.region.resolveSigV4aSigningRegionSet
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.auth.awscredentials.SigV4aClientConfig
 import aws.smithy.kotlin.runtime.client.AbstractSdkClientFactory
 import aws.smithy.kotlin.runtime.client.RetryStrategyClientConfig
@@ -73,7 +72,6 @@ public abstract class AbstractAwsSdkClientFactory<
     /**
      * Construct a [TClient] by resolving the configuration from the current environment.
      */
-    @OptIn(ExperimentalApi::class)
     public suspend fun fromEnvironment(block: (TConfigBuilder.() -> Unit)? = null): TClient {
         val builder = builder()
         val config = builder.config

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ atomicfu-version = "0.33.0"
 binary-compatibility-validator-version = "0.18.1"
 
 # smithy-kotlin
-smithy-kotlin-version = "1.7.7"
+smithy-kotlin-version = "1.7.8"
 
 # codegen
 smithy-version = "1.72.1"

--- a/services/s3/common/src/aws/sdk/kotlin/services/s3/express/DefaultS3ExpressCredentialsProvider.kt
+++ b/services/s3/common/src/aws/sdk/kotlin/services/s3/express/DefaultS3ExpressCredentialsProvider.kt
@@ -7,7 +7,6 @@ package aws.sdk.kotlin.services.s3.express
 import aws.sdk.kotlin.services.s3.*
 import aws.sdk.kotlin.services.s3.S3Attributes
 import aws.sdk.kotlin.services.s3.S3Client
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.auth.awscredentials.CloseableCredentialsProvider
 import aws.smithy.kotlin.runtime.auth.awscredentials.Credentials
 import aws.smithy.kotlin.runtime.auth.awscredentials.simpleClassName
@@ -97,7 +96,6 @@ internal class DefaultS3ExpressCredentialsProvider(
         credentialsCache.put(key, S3ExpressCredentialsCacheValue(it))
     }
 
-    @OptIn(ExperimentalApi::class)
     internal val S3Client.logger get() = config.telemetryProvider.loggerProvider.getLogger<DefaultS3ExpressCredentialsProvider>()
 
     override fun toString(): String = this.simpleClassName

--- a/tests/benchmarks/service-benchmarks/jvm/src/aws/sdk/kotlin/benchmarks/service/Common.kt
+++ b/tests/benchmarks/service-benchmarks/jvm/src/aws/sdk/kotlin/benchmarks/service/Common.kt
@@ -6,7 +6,6 @@ package aws.sdk.kotlin.benchmarks.service
 
 import aws.sdk.kotlin.benchmarks.service.telemetry.BenchmarkTelemetryProvider
 import aws.sdk.kotlin.benchmarks.service.telemetry.MetricAggregator
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.retries.StandardRetryStrategy
 import aws.smithy.kotlin.runtime.util.Uuid
 import kotlin.random.Random
@@ -18,7 +17,6 @@ object Common {
         maxAttempts = 1
     }
 
-    @OptIn(ExperimentalApi::class)
     val telemetryProvider = BenchmarkTelemetryProvider(metricAggregator)
 
     fun random(prefix: String = "") = "$prefix${Uuid.random()}"

--- a/tests/benchmarks/service-benchmarks/jvm/src/aws/sdk/kotlin/benchmarks/service/definitions/CloudwatchBenchmark.kt
+++ b/tests/benchmarks/service-benchmarks/jvm/src/aws/sdk/kotlin/benchmarks/service/definitions/CloudwatchBenchmark.kt
@@ -10,7 +10,6 @@ import aws.sdk.kotlin.services.cloudwatch.getMetricData
 import aws.sdk.kotlin.services.cloudwatch.model.MetricDataQuery
 import aws.sdk.kotlin.services.cloudwatch.model.MetricDatum
 import aws.sdk.kotlin.services.cloudwatch.putMetricData
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.time.Instant
 import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.milliseconds
@@ -21,7 +20,6 @@ private const val METRIC_NAME = "foo"
 private const val METRIC_VALUE = 42.0
 
 class CloudwatchBenchmark : ServiceBenchmark<CloudWatchClient> {
-    @OptIn(ExperimentalApi::class)
     override suspend fun client() = CloudWatchClient.fromEnvironment {
         retryStrategy = Common.noRetries
         telemetryProvider = Common.telemetryProvider

--- a/tests/benchmarks/service-benchmarks/jvm/src/aws/sdk/kotlin/benchmarks/service/definitions/CloudwatchEventsBenchmark.kt
+++ b/tests/benchmarks/service-benchmarks/jvm/src/aws/sdk/kotlin/benchmarks/service/definitions/CloudwatchEventsBenchmark.kt
@@ -7,7 +7,6 @@ package aws.sdk.kotlin.benchmarks.service.definitions
 import aws.sdk.kotlin.benchmarks.service.Common
 import aws.sdk.kotlin.services.cloudwatchevents.*
 import aws.sdk.kotlin.services.cloudwatchevents.model.PutEventsRequestEntry
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.time.Instant
 import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.milliseconds
@@ -15,7 +14,6 @@ import kotlin.time.Duration.Companion.milliseconds
 class CloudwatchEventsBenchmark : ServiceBenchmark<CloudWatchEventsClient> {
     private lateinit var eventBus: String
 
-    @OptIn(ExperimentalApi::class)
     override suspend fun client() = CloudWatchEventsClient.fromEnvironment {
         retryStrategy = Common.noRetries
         telemetryProvider = Common.telemetryProvider

--- a/tests/benchmarks/service-benchmarks/jvm/src/aws/sdk/kotlin/benchmarks/service/definitions/CloudwatchProtocolBenchmark.kt
+++ b/tests/benchmarks/service-benchmarks/jvm/src/aws/sdk/kotlin/benchmarks/service/definitions/CloudwatchProtocolBenchmark.kt
@@ -13,7 +13,6 @@ import aws.sdk.kotlin.services.cloudwatch.model.Metric
 import aws.sdk.kotlin.services.cloudwatch.model.MetricDataQuery
 import aws.sdk.kotlin.services.cloudwatch.model.MetricDatum
 import aws.sdk.kotlin.services.cloudwatch.putMetricData
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.time.Instant
 import java.util.*
 import kotlin.random.Random
@@ -27,7 +26,6 @@ class CloudwatchProtocolBenchmark : ServiceProtocolBenchmark<CloudWatchClient> {
         const val TEST_NAME_SPACE = "SDK Benchmark Test Data"
     }
 
-    @OptIn(ExperimentalApi::class)
     override suspend fun client() = CloudWatchClient.fromEnvironment {
         retryStrategy = Common.noRetries
         telemetryProvider = Common.telemetryProvider

--- a/tests/benchmarks/service-benchmarks/jvm/src/aws/sdk/kotlin/benchmarks/service/definitions/DynamoDbBenchmark.kt
+++ b/tests/benchmarks/service-benchmarks/jvm/src/aws/sdk/kotlin/benchmarks/service/definitions/DynamoDbBenchmark.kt
@@ -8,12 +8,10 @@ import aws.sdk.kotlin.benchmarks.service.Common
 import aws.sdk.kotlin.services.dynamodb.*
 import aws.sdk.kotlin.services.dynamodb.model.*
 import aws.sdk.kotlin.services.dynamodb.waiters.waitUntilTableExists
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 class DynamoDbBenchmark : ServiceBenchmark<DynamoDbClient> {
     private val table = Common.random("sdk-benchmark-table-")
 
-    @OptIn(ExperimentalApi::class)
     override suspend fun client() = DynamoDbClient.fromEnvironment {
         retryStrategy = Common.noRetries
         telemetryProvider = Common.telemetryProvider

--- a/tests/benchmarks/service-benchmarks/jvm/src/aws/sdk/kotlin/benchmarks/service/definitions/S3Benchmark.kt
+++ b/tests/benchmarks/service-benchmarks/jvm/src/aws/sdk/kotlin/benchmarks/service/definitions/S3Benchmark.kt
@@ -7,7 +7,6 @@ package aws.sdk.kotlin.benchmarks.service.definitions
 import aws.sdk.kotlin.benchmarks.service.Common
 import aws.sdk.kotlin.services.s3.*
 import aws.sdk.kotlin.services.s3.model.BucketLocationConstraint
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.content.ByteStream
 
 class S3Benchmark : ServiceBenchmark<S3Client> {
@@ -18,7 +17,6 @@ class S3Benchmark : ServiceBenchmark<S3Client> {
         private const val CONTENTS = "test-contents"
     }
 
-    @OptIn(ExperimentalApi::class)
     override suspend fun client() = S3Client.fromEnvironment {
         retryStrategy = Common.noRetries
         telemetryProvider = Common.telemetryProvider

--- a/tests/benchmarks/service-benchmarks/jvm/src/aws/sdk/kotlin/benchmarks/service/definitions/S3ExpressBenchmark.kt
+++ b/tests/benchmarks/service-benchmarks/jvm/src/aws/sdk/kotlin/benchmarks/service/definitions/S3ExpressBenchmark.kt
@@ -7,7 +7,6 @@ package aws.sdk.kotlin.benchmarks.service.definitions
 import aws.sdk.kotlin.benchmarks.service.Common
 import aws.sdk.kotlin.services.s3.*
 import aws.sdk.kotlin.services.s3.model.*
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.content.ByteStream
 
 private val KEY = "64kb-object"
@@ -23,7 +22,6 @@ class S3ExpressBenchmark : ServiceBenchmark<S3Client> {
         .substring(0 until 47) + // truncate to prevent "bucket name too long" errors
         "--$regionAz--x-s3"
 
-    @OptIn(ExperimentalApi::class)
     override suspend fun client() = S3Client.fromEnvironment {
         clientName = "S3Express"
         retryStrategy = Common.noRetries

--- a/tests/benchmarks/service-benchmarks/jvm/src/aws/sdk/kotlin/benchmarks/service/definitions/SecretsManagerBenchmark.kt
+++ b/tests/benchmarks/service-benchmarks/jvm/src/aws/sdk/kotlin/benchmarks/service/definitions/SecretsManagerBenchmark.kt
@@ -6,12 +6,10 @@ package aws.sdk.kotlin.benchmarks.service.definitions
 
 import aws.sdk.kotlin.benchmarks.service.Common
 import aws.sdk.kotlin.services.secretsmanager.*
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 class SecretsManagerBenchmark : ServiceBenchmark<SecretsManagerClient> {
     private val secretName = Common.random("sdk-benchmark-secret-name-")
 
-    @OptIn(ExperimentalApi::class)
     override suspend fun client() = SecretsManagerClient.fromEnvironment {
         retryStrategy = Common.noRetries
         telemetryProvider = Common.telemetryProvider

--- a/tests/benchmarks/service-benchmarks/jvm/src/aws/sdk/kotlin/benchmarks/service/definitions/SecretsManagerProtocolBenchmark.kt
+++ b/tests/benchmarks/service-benchmarks/jvm/src/aws/sdk/kotlin/benchmarks/service/definitions/SecretsManagerProtocolBenchmark.kt
@@ -10,7 +10,6 @@ import aws.sdk.kotlin.services.secretsmanager.*
 import aws.sdk.kotlin.services.secretsmanager.model.Filter
 import aws.sdk.kotlin.services.secretsmanager.model.FilterNameStringType
 import aws.sdk.kotlin.services.secretsmanager.model.Tag
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 class SecretsManagerProtocolBenchmark : ServiceProtocolBenchmark<SecretsManagerClient> {
     companion object {
@@ -18,7 +17,6 @@ class SecretsManagerProtocolBenchmark : ServiceProtocolBenchmark<SecretsManagerC
         private inline fun Int.padded(): String = String.format("%03d", this)
     }
 
-    @OptIn(ExperimentalApi::class)
     override suspend fun client() = SecretsManagerClient.fromEnvironment {
         retryStrategy = Common.noRetries
         telemetryProvider = Common.telemetryProvider

--- a/tests/benchmarks/service-benchmarks/jvm/src/aws/sdk/kotlin/benchmarks/service/definitions/SnsBenchmark.kt
+++ b/tests/benchmarks/service-benchmarks/jvm/src/aws/sdk/kotlin/benchmarks/service/definitions/SnsBenchmark.kt
@@ -6,12 +6,10 @@ package aws.sdk.kotlin.benchmarks.service.definitions
 
 import aws.sdk.kotlin.benchmarks.service.Common
 import aws.sdk.kotlin.services.sns.*
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 class SnsBenchmark : ServiceBenchmark<SnsClient> {
     private lateinit var arn: String
 
-    @OptIn(ExperimentalApi::class)
     override suspend fun client() = SnsClient.fromEnvironment {
         retryStrategy = Common.noRetries
         telemetryProvider = Common.telemetryProvider

--- a/tests/benchmarks/service-benchmarks/jvm/src/aws/sdk/kotlin/benchmarks/service/definitions/StsBenchmark.kt
+++ b/tests/benchmarks/service-benchmarks/jvm/src/aws/sdk/kotlin/benchmarks/service/definitions/StsBenchmark.kt
@@ -11,7 +11,6 @@ import aws.sdk.kotlin.services.iam.deleteRole
 import aws.sdk.kotlin.services.sts.StsClient
 import aws.sdk.kotlin.services.sts.assumeRole
 import aws.sdk.kotlin.services.sts.model.StsException
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.io.use
 import aws.smithy.kotlin.runtime.telemetry.TelemetryProvider
 import kotlinx.coroutines.delay
@@ -19,7 +18,6 @@ import kotlinx.coroutines.withTimeout
 import kotlin.time.Duration.Companion.seconds
 
 class StsBenchmark : ServiceBenchmark<StsClient> {
-    @OptIn(ExperimentalApi::class)
     override suspend fun client() = StsClient.fromEnvironment {
         retryStrategy = Common.noRetries
         telemetryProvider = Common.telemetryProvider

--- a/tests/benchmarks/service-benchmarks/jvm/src/aws/sdk/kotlin/benchmarks/service/telemetry/BenchmarkTelemetryProvider.kt
+++ b/tests/benchmarks/service-benchmarks/jvm/src/aws/sdk/kotlin/benchmarks/service/telemetry/BenchmarkTelemetryProvider.kt
@@ -4,7 +4,6 @@
  */
 package aws.sdk.kotlin.benchmarks.service.telemetry
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.collections.Attributes
 import aws.smithy.kotlin.runtime.telemetry.AbstractTelemetryProvider
 import aws.smithy.kotlin.runtime.telemetry.context.Context
@@ -21,7 +20,6 @@ private val capturedMetrics = mapOf(
     // "smithy.client.call.response_payload_size" to "RespSize",
 )
 
-@ExperimentalApi
 class BenchmarkTelemetryProvider(private val metricAggregator: MetricAggregator) : AbstractTelemetryProvider() {
     override val meterProvider = object : AbstractMeterProvider() {
         override fun getOrCreateMeter(scope: String) = object : AbstractMeter() {


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

The telemetry system has been stable for quite a long time and shouldn't be marked as "experimental" anymore.

**Companion PR**: https://github.com/smithy-lang/smithy-kotlin/pull/1684

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
