### PR TITLE
chore: add support for external PR CI

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -1,0 +1,50 @@
+# Branch protection configuration
+
+This repo runs CI from two origins that produce status checks under **different
+names**, so branch protection is configured against a single aggregate context
+that both origins produce under the same name.
+
+## The one required status context
+
+Configure exactly one required status check on protected branches:
+
+- **`required`**
+
+Both the same-repo aggregate (`.github/workflows/ci-required.yml`) and the
+privileged fork-PR entrypoint (`.github/workflows/external-pr-ci.yml`) produce a
+job named `required`, so this single rule covers both origins.
+
+## Why the individual checks are not listed as required
+
+Fork PRs and same-repo PRs produce status contexts under different names:
+
+- **Fork PRs** run through the privileged entrypoint
+  (`external-pr-ci.yml`), which calls the reusable workflows via `uses:`. Reusable
+  workflow job contexts are **prefixed by the caller job name**, e.g.
+  `ci / jvm (17)`, `reduced-ci / jvm (17)`, `service-ci / build-sdk`.
+- **Same-repo PRs** run each workflow directly via its own `pull_request` /
+  `merge_group` triggers, producing **unprefixed** contexts, e.g. `jvm (17)`,
+  `build-sdk`, `verify-transform`.
+
+A context that can only ever be produced by **one** origin must **not** be marked
+required: it would block the other origin's PRs forever (the check would never
+report). For example, marking `ci / jvm (17)` required would block every same-repo
+PR (which only ever produces `jvm (17)`), and marking `jvm (17)` required would
+block every fork PR (which only ever produces `ci / jvm (17)`).
+
+The `required` aggregate is the only context emitted under the same name on both
+paths, which is why it is the sole required check.
+
+## Caveat on the same-repo aggregate
+
+`ci-required.yml`'s `required` job is a naming shim: it produces the aggregate
+context on the same-repo path, but it does **not** itself depend on or gate the
+individual same-repo checks (`jvm`, `all-platforms`, `verify-transform`,
+`build-sdk`, `e2e-tests`, `changelog-verification`). Those same-repo checks run
+independently via their own triggers and should remain individually required
+**for the same-repo path** if you want them enforced there — but per the rule
+above, only enforce contexts that the same-repo path actually produces.
+
+On the fork-PR path the aggregate is real gating: `external-pr-ci.yml`'s
+`required` job `needs:` all six caller jobs and fails if any failed or was
+cancelled.

--- a/.github/workflows/changelog-verification.yml
+++ b/.github/workflows/changelog-verification.yml
@@ -12,6 +12,15 @@ on:
       - '*-main'
   merge_group:
     types: [checks_requested]
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        required: false
+        default: ''
+    secrets:
+      CI_AWS_ROLE_ARN:
+        required: true
 
 jobs:
   changelog-verification:
@@ -27,3 +36,5 @@ jobs:
 
       - name: Verify changelog
         uses: aws/aws-kotlin-repo-tools/.github/actions/changelog-verification@main
+        with:
+          ref: ${{ inputs.ref }}

--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -1,0 +1,22 @@
+name: CI Required
+
+# Produces the aggregate `required` status context on the same-repo path under the
+# SAME name the privileged entrypoint (external-pr-ci.yml) produces, so a single
+# branch-protection rule ("required") covers both same-repo and fork-PR origins.
+#
+# Limitation: this job does NOT itself gate the individual same-repo checks (jvm,
+# all-platforms, verify-transform, build-sdk, e2e-tests, changelog-verification).
+# Those checks run via each workflow's own `pull_request` / `merge_group` triggers
+# and remain independently required. See .github/BRANCH_PROTECTION.md.
+
+on:
+  pull_request:
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  required:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate required (same-repo)
+        run: echo "Same-repo CI aggregate succeeded."

--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -14,6 +14,9 @@ on:
   merge_group:
     types: [checks_requested]
 
+permissions:
+  contents: read
+
 jobs:
   required:
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-integration-reduced.yml
+++ b/.github/workflows/continuous-integration-reduced.yml
@@ -7,6 +7,15 @@ on:
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        required: false
+        default: ''
+    secrets:
+      CI_AWS_ROLE_ARN:
+        required: true
 
 permissions:
   id-token: write
@@ -46,6 +55,8 @@ jobs:
 
       - name: Checkout SDK
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Configure Gradle (SDK)
         uses: aws/aws-kotlin-repo-tools/.github/actions/configure-gradle@main

--- a/.github/workflows/continuous-integration-reduced.yml
+++ b/.github/workflows/continuous-integration-reduced.yml
@@ -22,7 +22,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-reduced-pr-${{ github.ref }}
+  group: ci-reduced-pr-${{ inputs.ref || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,6 +5,15 @@ on:
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        required: false
+        default: ''
+    secrets:
+      CI_AWS_ROLE_ARN:
+        required: true
 
 permissions:
   id-token: write
@@ -38,6 +47,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.ref }}
           path: 'aws-sdk-kotlin'
       - name: Setup Build
         uses: ./aws-sdk-kotlin/.github/actions/setup-build
@@ -99,6 +109,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.ref }}
           path: 'aws-sdk-kotlin'
       - name: Setup Build
         uses: ./aws-sdk-kotlin/.github/actions/setup-build

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,7 +20,7 @@ permissions:
   contents: read
 # Allow one instance of this workflow per pull request, and cancel older runs when new changes are pushed
 concurrency:
-  group: ci-pr-${{ github.ref }}
+  group: ci-pr-${{ inputs.ref || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,6 +5,15 @@ on:
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        required: false
+        default: ''
+    secrets:
+      CI_AWS_ROLE_ARN:
+        required: true
 
 concurrency:
   group: e2e-tests-${{ github.ref }}
@@ -29,7 +38,7 @@ jobs:
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
           project-name: gh-aws-sdk-kotlin-e2e-tests
-          source-version-override: ${{ github.ref }}
+          source-version-override: ${{ inputs.ref || github.ref }}
 
       - name: Cancel
         if: ${{ cancelled() }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -16,7 +16,7 @@ on:
         required: true
 
 concurrency:
-  group: e2e-tests-${{ github.ref }}
+  group: e2e-tests-${{ inputs.ref || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/external-pr-ci.yml
+++ b/.github/workflows/external-pr-ci.yml
@@ -1,0 +1,101 @@
+name: External PR CI (privileged)
+
+on:
+  pull_request_target:
+    types: [labeled, synchronize]
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: external-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      approved: ${{ steps.check.outputs.approved }}
+    steps:
+      - name: Revoke approval on new commits
+        if: ${{ github.event.action == 'synchronize' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --remove-label safe-to-test || true
+
+      - name: Determine whether to run
+        id: check
+        run: |
+          if [ "${{ github.event.action }}" == "labeled" ] \
+            && [ "${{ github.event.label.name }}" == "safe-to-test" ] \
+            && [ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]; then
+            echo "approved=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "approved=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  ci:
+    needs: gate
+    if: ${{ needs.gate.outputs.approved == 'true' }}
+    uses: ./.github/workflows/continuous-integration.yml
+    secrets: inherit
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+
+  reduced-ci:
+    needs: gate
+    if: ${{ needs.gate.outputs.approved == 'true' }}
+    uses: ./.github/workflows/continuous-integration-reduced.yml
+    secrets: inherit
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+
+  kat-transform:
+    needs: gate
+    if: ${{ needs.gate.outputs.approved == 'true' }}
+    uses: ./.github/workflows/kat-transform.yml
+    secrets: inherit
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+
+  service-ci:
+    needs: gate
+    if: ${{ needs.gate.outputs.approved == 'true' }}
+    uses: ./.github/workflows/service-ci.yml
+    secrets: inherit
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+
+  e2e-tests:
+    needs: gate
+    if: ${{ needs.gate.outputs.approved == 'true' }}
+    uses: ./.github/workflows/e2e-tests.yml
+    secrets: inherit
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+
+  changelog:
+    needs: gate
+    if: ${{ needs.gate.outputs.approved == 'true' }}
+    uses: ./.github/workflows/changelog-verification.yml
+    secrets: inherit
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+
+  required:
+    if: ${{ always() }}
+    needs: [ci, reduced-ci, kat-transform, service-ci, e2e-tests, changelog]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all caller jobs succeeded
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]; then
+            echo "One or more required CI jobs failed or were cancelled."
+            exit 1
+          fi
+          echo "All required CI jobs succeeded."

--- a/.github/workflows/kat-transform.yml
+++ b/.github/workflows/kat-transform.yml
@@ -8,6 +8,15 @@ on:
       - '*-main'
   merge_group:
     types: [checks_requested]
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        required: false
+        default: ''
+    secrets:
+      CI_AWS_ROLE_ARN:
+        required: true
 
 # Allow one instance of this workflow per pull request, and cancel older runs when new changes are pushed
 concurrency:
@@ -29,6 +38,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.ref }}
           path: 'aws-sdk-kotlin'
 
       - name: Setup Build

--- a/.github/workflows/kat-transform.yml
+++ b/.github/workflows/kat-transform.yml
@@ -20,7 +20,7 @@ on:
 
 # Allow one instance of this workflow per pull request, and cancel older runs when new changes are pushed
 concurrency:
-  group: kat-pr-${{ github.ref }}
+  group: kat-pr-${{ inputs.ref || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/service-ci.yml
+++ b/.github/workflows/service-ci.yml
@@ -5,6 +5,15 @@ on:
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        required: false
+        default: ''
+    secrets:
+      CI_AWS_ROLE_ARN:
+        required: true
 
 concurrency:
   group: service-ci-${{ github.ref }}
@@ -34,7 +43,7 @@ jobs:
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
           project-name: aws-sdk-kotlin-service-build
-          source-version-override: ${{ github.ref }}
+          source-version-override: ${{ inputs.ref || github.ref }}
           env-vars-for-codebuild: GITHUB_REPOSITORY, UPLOAD, RELEASE_METRICS, IDENTIFIER
 
       - name: Process metrics

--- a/.github/workflows/service-ci.yml
+++ b/.github/workflows/service-ci.yml
@@ -16,7 +16,7 @@ on:
         required: true
 
 concurrency:
-  group: service-ci-${{ github.ref }}
+  group: service-ci-${{ inputs.ref || github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Add support for external PRs to successfully execute CI workflows after being approved by a maintainer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
