### PR TITLE
Charge the correct retry token cost for transient retries 

### DIFF
--- a/.changes/2810db5d-692f-4926-b46d-6b49a38e4796.json
+++ b/.changes/2810db5d-692f-4926-b46d-6b49a38e4796.json
@@ -1,0 +1,6 @@
+{
+    "id": "2810db5d-692f-4926-b46d-6b49a38e4796",
+    "type": "bugfix",
+    "description": "Charge the correct retry token cost for transient retries when the new retry behavior is enabled via the `AWS_NEW_RETRIES_2026` environment variable",
+    "module": "aws-config"
+}

--- a/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/config/retries/ResolveRetryStrategy.kt
+++ b/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/config/retries/ResolveRetryStrategy.kt
@@ -121,6 +121,7 @@ internal fun StandardRetryStrategy.Config.Builder.configureRetryDefaults(
     }
 
     tokenBucket {
+        this.useNewRetries = true
         retryCost = STANDARD_RETRY_COST
         timeoutRetryCost = STANDARD_THROTTLING_RETRY_COST
     }

--- a/aws-runtime/aws-config/common/test/aws/sdk/kotlin/runtime/config/retries/ResolveRetryStrategyTest.kt
+++ b/aws-runtime/aws-config/common/test/aws/sdk/kotlin/runtime/config/retries/ResolveRetryStrategyTest.kt
@@ -12,7 +12,9 @@ import aws.smithy.kotlin.runtime.ClientException
 import aws.smithy.kotlin.runtime.retries.AdaptiveRetryStrategy
 import aws.smithy.kotlin.runtime.retries.StandardRetryStrategy
 import aws.smithy.kotlin.runtime.retries.delay.ExponentialBackoffWithJitter
+import aws.smithy.kotlin.runtime.retries.delay.RetryCapacityExceededException
 import aws.smithy.kotlin.runtime.retries.delay.StandardRetryTokenBucket
+import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
 import aws.smithy.kotlin.runtime.util.TestFile
 import aws.smithy.kotlin.runtime.util.TestPlatformProvider
 import aws.smithy.kotlin.runtime.util.asyncLazy
@@ -276,6 +278,34 @@ class ResolveRetryStrategyTest {
         assertEquals(STANDARD_RETRY_COST, bucketConfig.retryCost)
         assertEquals(STANDARD_THROTTLING_RETRY_COST, bucketConfig.timeoutRetryCost)
         assertTrue(strategy.config.enableLongPollingBackoff)
+    }
+
+    @Test
+    fun itChargesFullRetryCostForTransientRetriesWhenNewRetriesEnabled() = runTest {
+        // Regression test for the AWS_NEW_RETRIES_2026 propagation bug: the token bucket must charge
+        // STANDARD_RETRY_COST (14) — not STANDARD_THROTTLING_RETRY_COST (5) — for transient retries when the new
+        // behavior is enabled via the AWS setting rather than smithy-kotlin's SMITHY_NEW_RETRIES_2026.
+        val platform = TestPlatformProvider.of(
+            env = mapOf(AwsSdkSetting.AwsNewRetries.envVar to "true"),
+        )
+
+        val strategy = assertIs<StandardRetryStrategy>(resolveRetryStrategy(platform))
+        val bucket = strategy.config.tokenBucket
+
+        // Default bucket: maxCapacity=500, circuit-breaker mode, initialTryCost=0. Schedule transient retries until
+        // capacity is exhausted; the count reveals the per-retry cost.
+        var token = bucket.acquireToken()
+        var transientRetries = 0
+        val result = runCatching {
+            while (true) {
+                token = token.scheduleRetry(RetryErrorType.Transient)
+                transientRetries++
+            }
+        }
+
+        assertIs<RetryCapacityExceededException>(result.exceptionOrNull())
+        // 500 / 14 = 35 successful transient retries. Under the bug (cost 5) this would have been 100.
+        assertEquals(500 / STANDARD_RETRY_COST, transientRetries)
     }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ atomicfu-version = "0.33.0"
 binary-compatibility-validator-version = "0.18.2"
 
 # smithy-kotlin
-smithy-kotlin-version = "1.7.9"
+smithy-kotlin-version = "1.7.10"
 
 # codegen
 smithy-version = "1.73.0"


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Charge the correct retry token cost for transient retries when the new retry behavior is enabled via the `AWS_NEW_RETRIES_2026` environment variable

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
