### PR TITLE
feat: add AWS Lambda SnapStart support

### DIFF
--- a/.changes/83e166be-7a38-4db5-b7ea-719fd1016427.json
+++ b/.changes/83e166be-7a38-4db5-b7ea-719fd1016427.json
@@ -1,0 +1,6 @@
+{
+    "id": "83e166be-7a38-4db5-b7ea-719fd1016427",
+    "type": "feature",
+    "description": "Add AWS Lambda SnapStart support for default SDK resources",
+    "module": "aws-config"
+}

--- a/aws-runtime/aws-config/api/aws-config.api
+++ b/aws-runtime/aws-config/api/aws-config.api
@@ -264,6 +264,7 @@ public final class aws/sdk/kotlin/runtime/auth/credentials/internal/ManagedCrede
 
 public abstract class aws/sdk/kotlin/runtime/config/AbstractAwsSdkClientFactory : aws/smithy/kotlin/runtime/client/AbstractSdkClientFactory {
 	public fun <init> ()V
+	protected fun finalizeConfig (Laws/smithy/kotlin/runtime/client/SdkClient$Builder;)V
 	protected fun finalizeEnvironmentalConfig (Laws/smithy/kotlin/runtime/client/SdkClient$Builder;Laws/smithy/kotlin/runtime/util/LazyAsyncValue;Laws/smithy/kotlin/runtime/util/LazyAsyncValue;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun fromEnvironment (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun fromEnvironment$default (Laws/sdk/kotlin/runtime/config/AbstractAwsSdkClientFactory;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;

--- a/aws-runtime/aws-config/build.gradle.kts
+++ b/aws-runtime/aws-config/build.gradle.kts
@@ -14,8 +14,6 @@ plugins {
 description = "Support for AWS configuration"
 extra["moduleName"] = "aws.sdk.kotlin.runtime.config"
 
-apply(plugin = "org.jetbrains.kotlinx.atomicfu")
-
 kotlin {
     sourceSets {
         commonMain {
@@ -56,10 +54,17 @@ kotlin {
                 implementation(libs.kotlinx.serialization.json)
             }
         }
+        jvmMain {
+            dependencies {
+                implementation(libs.crac)
+                implementation(libs.smithy.kotlin.http.client.engine.okhttp)
+            }
+        }
         jvmTest {
             dependencies {
                 implementation(libs.mockk)
                 implementation(libs.kaml)
+                implementation(libs.smithy.kotlin.http.client.engine.okhttp4)
             }
         }
 

--- a/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/auth/credentials/DefaultChainBearerTokenProvider.kt
+++ b/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/auth/credentials/DefaultChainBearerTokenProvider.kt
@@ -6,11 +6,17 @@
 package aws.sdk.kotlin.runtime.auth.credentials
 
 import aws.sdk.kotlin.runtime.config.AwsSdkSetting
+import aws.sdk.kotlin.runtime.config.CheckpointRestoreLifecycle
+import aws.sdk.kotlin.runtime.config.CheckpointRestoreLock
+import aws.sdk.kotlin.runtime.config.createCheckpointRestoreLock
+import aws.sdk.kotlin.runtime.config.isCheckpointRestoreEnvironment
+import aws.sdk.kotlin.runtime.config.withLock
 import aws.smithy.kotlin.runtime.collections.Attributes
 import aws.smithy.kotlin.runtime.http.auth.BearerToken
 import aws.smithy.kotlin.runtime.http.auth.BearerTokenProviderChain
 import aws.smithy.kotlin.runtime.http.auth.CloseableBearerTokenProvider
 import aws.smithy.kotlin.runtime.http.engine.HttpClientEngine
+import aws.smithy.kotlin.runtime.identity.IdentityProviderException
 import aws.smithy.kotlin.runtime.io.Closeable
 import aws.smithy.kotlin.runtime.util.PlatformProvider
 
@@ -35,13 +41,64 @@ public class DefaultChainBearerTokenProvider(
     public val httpClient: HttpClientEngine? = null,
 ) : CloseableBearerTokenProvider {
 
-    private val chain = BearerTokenProviderChain(
-        ProfileBearerTokenProvider(profileName, platformProvider, httpClient),
-    )
+    private val lifecycleLock = createCheckpointRestoreLock()
+    private var chain: BearerTokenProviderChain? = createChain()
+    private var closed = false
+    private var checkpointed = false
 
-    override suspend fun resolve(attributes: Attributes): BearerToken = chain.resolve(attributes)
+    @Suppress("unused")
+    private val checkpointRestoreLifecycle = if (isCheckpointRestoreEnvironment()) {
+        CheckpointRestoreLifecycle(::beforeCheckpoint, ::afterRestore).register()
+    } else {
+        null
+    }
+
+    override suspend fun resolve(attributes: Attributes): BearerToken {
+        val providerChain = lifecycleLock.withLock { chain }
+        return providerChain?.resolve(attributes)
+            ?: throw IdentityProviderException("Bearer token provider is unavailable during a checkpoint")
+    }
 
     override fun close() {
-        chain.close()
+        val providerChain = lifecycleLock.withLock {
+            if (closed) return
+            closed = true
+            chain.also { chain = null }
+        }
+        providerChain?.close()
     }
+
+    internal fun beforeCheckpoint() {
+        val providerChain = lifecycleLock.withLock {
+            if (closed || checkpointed) return
+            checkpointed = true
+            chain.also { chain = null }
+        }
+        try {
+            providerChain?.close()
+        } catch (ex: Exception) {
+            recoverFromFailedCheckpoint()
+            throw IllegalStateException("Failed to close the default bearer-token provider before the checkpoint", ex)
+        }
+    }
+
+    internal fun afterRestore() {
+        lifecycleLock.withLock {
+            if (closed || !checkpointed) return
+            chain = createChain()
+            checkpointed = false
+        }
+    }
+
+    private fun recoverFromFailedCheckpoint() {
+        lifecycleLock.withLock {
+            if (closed || !checkpointed) return
+            chain = createChain()
+            checkpointed = false
+        }
+    }
+
+    private fun createChain(): BearerTokenProviderChain = BearerTokenProviderChain(
+        ProfileBearerTokenProvider(profileName, platformProvider, httpClient),
+    )
 }

--- a/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/auth/credentials/DefaultChainCredentialsProvider.kt
+++ b/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/auth/credentials/DefaultChainCredentialsProvider.kt
@@ -6,12 +6,17 @@
 package aws.sdk.kotlin.runtime.auth.credentials
 
 import aws.sdk.kotlin.runtime.config.AwsSdkSetting
+import aws.sdk.kotlin.runtime.config.CheckpointRestoreLifecycle
+import aws.sdk.kotlin.runtime.config.CheckpointRestoreLock
+import aws.sdk.kotlin.runtime.config.createCheckpointRestoreAwareDefaultHttpEngine
+import aws.sdk.kotlin.runtime.config.createCheckpointRestoreLock
 import aws.sdk.kotlin.runtime.config.imds.ImdsClient
+import aws.sdk.kotlin.runtime.config.isCheckpointRestoreEnvironment
+import aws.sdk.kotlin.runtime.config.withLock
 import aws.sdk.kotlin.runtime.http.interceptors.businessmetrics.AwsBusinessMetric
 import aws.sdk.kotlin.runtime.http.interceptors.businessmetrics.withBusinessMetric
 import aws.smithy.kotlin.runtime.auth.awscredentials.*
 import aws.smithy.kotlin.runtime.collections.Attributes
-import aws.smithy.kotlin.runtime.http.engine.DefaultHttpEngine
 import aws.smithy.kotlin.runtime.http.engine.HttpClientEngine
 import aws.smithy.kotlin.runtime.io.Closeable
 import aws.smithy.kotlin.runtime.io.closeIfCloseable
@@ -49,38 +54,98 @@ public class DefaultChainCredentialsProvider constructor(
 ) : CloseableCredentialsProvider {
 
     private val manageEngine = httpClient == null
-    private val engine = httpClient ?: DefaultHttpEngine()
+    private val engine = httpClient ?: createCheckpointRestoreAwareDefaultHttpEngine()
 
-    private val chain = CredentialsProviderChain(
-        SystemPropertyCredentialsProvider(platformProvider::getProperty),
-        EnvironmentCredentialsProvider(platformProvider::getenv),
-        // STS web identity provider can be constructed from either the profile OR 100% from the environment
-        StsWebIdentityProvider(platformProvider = platformProvider, httpClient = engine, region = region),
-        ProfileCredentialsProvider(profileName = profileName, platformProvider = platformProvider, httpClient = engine, region = region),
-        EcsCredentialsProvider(platformProvider, engine),
-        ImdsCredentialsProvider(
-            client = lazy {
-                ImdsClient {
-                    platformProvider = this@DefaultChainCredentialsProvider.platformProvider
-                    engine = this@DefaultChainCredentialsProvider.engine
-                }
-            },
-            platformProvider = platformProvider,
-        ),
-    )
+    private val lifecycleLock = createCheckpointRestoreLock()
+    private var state: ProviderState? = createState()
+    private var closed = false
+    private var checkpointed = false
 
-    private val provider = CachedCredentialsProvider(chain)
+    @Suppress("unused")
+    private val checkpointRestoreLifecycle = if (isCheckpointRestoreEnvironment()) {
+        CheckpointRestoreLifecycle(::beforeCheckpoint, ::afterRestore).register()
+    } else {
+        null
+    }
 
-    override suspend fun resolve(attributes: Attributes): Credentials = provider.resolve(attributes)
+    override suspend fun resolve(attributes: Attributes): Credentials {
+        val provider = lifecycleLock.withLock { state?.provider }
+        return provider?.resolve(attributes)
+            ?: throw CredentialsProviderException("Credentials provider is unavailable during a checkpoint")
+    }
 
     override fun close() {
-        provider.close()
-        if (manageEngine) {
-            engine.closeIfCloseable()
+        val provider = lifecycleLock.withLock {
+            if (closed) return
+            closed = true
+            state.also { state = null }?.provider
+        }
+        try {
+            provider?.close()
+        } finally {
+            if (manageEngine) {
+                engine.closeIfCloseable()
+            }
         }
     }
 
-    override fun toString(): String = this.simpleClassName + ": " + this.chain
+    override fun toString(): String = this.simpleClassName + ": " + lifecycleLock.withLock { state?.chain }
+
+    internal fun beforeCheckpoint() {
+        val provider = lifecycleLock.withLock {
+            if (closed || checkpointed) return
+            checkpointed = true
+            state.also { state = null }?.provider
+        }
+        try {
+            provider?.close()
+        } catch (ex: Exception) {
+            recoverFromFailedCheckpoint()
+            throw IllegalStateException("Failed to close the default credentials provider before the checkpoint", ex)
+        }
+    }
+
+    internal fun afterRestore() {
+        lifecycleLock.withLock {
+            if (closed || !checkpointed) return
+            state = createState()
+            checkpointed = false
+        }
+    }
+
+    private fun recoverFromFailedCheckpoint() {
+        lifecycleLock.withLock {
+            if (closed || !checkpointed) return
+            state = createState()
+            checkpointed = false
+        }
+    }
+
+    private fun createState(): ProviderState {
+        val chain = CredentialsProviderChain(
+            SystemPropertyCredentialsProvider(platformProvider::getProperty),
+            EnvironmentCredentialsProvider(platformProvider::getenv),
+            // STS web identity provider can be constructed from either the profile OR 100% from the environment
+            StsWebIdentityProvider(platformProvider = platformProvider, httpClient = engine, region = region),
+            ProfileCredentialsProvider(profileName = profileName, platformProvider = platformProvider, httpClient = engine, region = region),
+            EcsCredentialsProvider(platformProvider, engine),
+            ImdsCredentialsProvider(
+                client = lazy {
+                    ImdsClient {
+                        platformProvider = this@DefaultChainCredentialsProvider.platformProvider
+                        engine = this@DefaultChainCredentialsProvider.engine
+                    }
+                },
+                platformProvider = platformProvider,
+            ),
+        )
+        return ProviderState(chain, CachedCredentialsProvider(chain))
+    }
+
+    private data class ProviderState(
+        val chain: CredentialsProviderChain,
+        val provider: CachedCredentialsProvider,
+    )
 }
 
 /**

--- a/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/config/AbstractAwsSdkClientFactory.kt
+++ b/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/config/AbstractAwsSdkClientFactory.kt
@@ -30,6 +30,7 @@ import aws.smithy.kotlin.runtime.client.config.CompressionClientConfig
 import aws.smithy.kotlin.runtime.client.config.HttpChecksumConfig
 import aws.smithy.kotlin.runtime.config.resolve
 import aws.smithy.kotlin.runtime.http.auth.HttpAuthConfig
+import aws.smithy.kotlin.runtime.http.config.HttpEngineConfig
 import aws.smithy.kotlin.runtime.telemetry.TelemetryConfig
 import aws.smithy.kotlin.runtime.telemetry.TelemetryProvider
 import aws.smithy.kotlin.runtime.telemetry.trace.withSpan
@@ -56,6 +57,11 @@ public abstract class AbstractAwsSdkClientFactory<
           TConfig : AwsSdkClientConfig,
           TConfigBuilder : SdkClientConfig.Builder<TConfig>,
           TConfigBuilder : AwsSdkClientConfig.Builder {
+
+    override fun finalizeConfig(builder: TClientBuilder) {
+        super.finalizeConfig(builder)
+        (builder.config as? HttpEngineConfig.Builder)?.configureCheckpointRestore()
+    }
 
     /**
      * Service-specific default max attempts for the retry strategy.

--- a/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/config/CheckpointRestore.kt
+++ b/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/config/CheckpointRestore.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.sdk.kotlin.runtime.config
+
+import aws.smithy.kotlin.runtime.http.config.HttpEngineConfig
+import aws.smithy.kotlin.runtime.http.engine.HttpClientEngine
+
+internal abstract class CheckpointRestorePlatform {
+    internal abstract val isActive: Boolean
+
+    internal abstract fun register(lifecycle: CheckpointRestoreLifecycle): Any?
+
+    internal abstract fun configureHttpEngine(builder: HttpEngineConfig.Builder)
+
+    internal abstract fun createDefaultHttpEngine(): HttpClientEngine
+}
+
+internal expect val checkpointRestorePlatform: CheckpointRestorePlatform
+
+internal interface CheckpointRestoreLock {
+    fun lock()
+
+    fun unlock()
+}
+
+internal expect fun createCheckpointRestoreLock(): CheckpointRestoreLock
+
+internal inline fun <T> CheckpointRestoreLock.withLock(block: () -> T): T {
+    lock()
+    try {
+        return block()
+    } finally {
+        unlock()
+    }
+}
+
+internal class CheckpointRestoreLifecycle(
+    private val beforeCheckpointHook: () -> Unit,
+    private val afterRestoreHook: () -> Unit,
+) {
+    @Suppress("unused")
+    private var registration: Any? = null
+    private var registered = false
+
+    internal fun register(): CheckpointRestoreLifecycle = apply {
+        check(!registered) { "Checkpoint/restore lifecycle is already registered" }
+        registered = true
+        registration = checkpointRestorePlatform.register(this)
+    }
+
+    internal fun beforeCheckpoint(): Unit = beforeCheckpointHook()
+
+    internal fun afterRestore(): Unit = afterRestoreHook()
+}
+
+internal fun isCheckpointRestoreEnvironment(): Boolean = checkpointRestorePlatform.isActive
+
+internal fun HttpEngineConfig.Builder.configureCheckpointRestore() {
+    checkpointRestorePlatform.configureHttpEngine(this)
+}
+
+internal fun createCheckpointRestoreAwareDefaultHttpEngine(): HttpClientEngine = checkpointRestorePlatform.createDefaultHttpEngine()

--- a/aws-runtime/aws-config/common/test/aws/sdk/kotlin/runtime/auth/credentials/DefaultChainBearerTokenProviderTest.kt
+++ b/aws-runtime/aws-config/common/test/aws/sdk/kotlin/runtime/auth/credentials/DefaultChainBearerTokenProviderTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.sdk.kotlin.runtime.auth.credentials
+
+import aws.smithy.kotlin.runtime.identity.IdentityProviderException
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class DefaultChainBearerTokenProviderTest {
+    @Test
+    fun testCheckpointAndRestoreHooksArePairedAndIdempotent() = runTest {
+        val provider = DefaultChainBearerTokenProvider()
+
+        provider.afterRestore()
+        provider.beforeCheckpoint()
+        provider.beforeCheckpoint()
+        assertFailsWith<IdentityProviderException> { provider.resolve() }
+
+        provider.afterRestore()
+        provider.afterRestore()
+        provider.close()
+    }
+
+    @Test
+    fun testCloseDuringCheckpointPreventsRestore() = runTest {
+        val provider = DefaultChainBearerTokenProvider()
+
+        provider.beforeCheckpoint()
+        provider.close()
+        provider.afterRestore()
+
+        assertFailsWith<IdentityProviderException> { provider.resolve() }
+    }
+}

--- a/aws-runtime/aws-config/jvm/src/aws/sdk/kotlin/runtime/config/CheckpointRestoreJVM.kt
+++ b/aws-runtime/aws-config/jvm/src/aws/sdk/kotlin/runtime/config/CheckpointRestoreJVM.kt
@@ -1,0 +1,258 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.sdk.kotlin.runtime.config
+
+import aws.smithy.kotlin.runtime.http.HttpCall
+import aws.smithy.kotlin.runtime.http.config.HttpEngineConfig
+import aws.smithy.kotlin.runtime.http.engine.CloseableHttpClientEngine
+import aws.smithy.kotlin.runtime.http.engine.DefaultHttpEngine
+import aws.smithy.kotlin.runtime.http.engine.HttpClientEngine
+import aws.smithy.kotlin.runtime.http.engine.HttpClientEngineConfig
+import aws.smithy.kotlin.runtime.http.engine.okhttp.OkHttpEngine
+import aws.smithy.kotlin.runtime.http.engine.okhttp.OkHttpEngineConfig
+import aws.smithy.kotlin.runtime.http.request.HttpRequest
+import aws.smithy.kotlin.runtime.io.SdkManaged
+import aws.smithy.kotlin.runtime.io.SdkManagedBase
+import aws.smithy.kotlin.runtime.operation.ExecutionContext
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.crac.Context
+import org.crac.Core
+import org.crac.Resource
+import java.lang.ref.WeakReference
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.coroutines.CoroutineContext
+
+private const val LAMBDA_INITIALIZATION_TYPE = "AWS_LAMBDA_INITIALIZATION_TYPE"
+private const val SNAP_START = "snap-start"
+private const val OKHTTP_ENGINE_NAME = "http-client-engine-OkHttp-context"
+private const val OKHTTP4_ENGINE_NAME = "http-client-engine-OkHttp4-context"
+private const val OKHTTP4_ENGINE_CLASS = "aws.smithy.kotlin.runtime.http.engine.okhttp4.OkHttp4Engine"
+private const val CHECKPOINT_QUIESCENCE_TIMEOUT_MILLIS = 10_000L
+
+internal actual val checkpointRestorePlatform: CheckpointRestorePlatform = LambdaSnapStartCracPlatform()
+
+internal actual fun createCheckpointRestoreLock(): CheckpointRestoreLock = JvmCheckpointRestoreLock()
+
+private class JvmCheckpointRestoreLock : CheckpointRestoreLock {
+    private val delegate = ReentrantLock()
+
+    override fun lock(): Unit = delegate.lock()
+
+    override fun unlock(): Unit = delegate.unlock()
+}
+
+private class LambdaSnapStartCracPlatform : CheckpointRestorePlatform() {
+    private val enabled = System.getenv(LAMBDA_INITIALIZATION_TYPE) == SNAP_START
+    private val registrationLock = createCheckpointRestoreLock()
+    private var restored = false
+
+    override val isActive: Boolean
+        get() = registrationLock.withLock { enabled && !restored }
+
+    override fun register(lifecycle: CheckpointRestoreLifecycle): Any? {
+        val resource = registrationLock.withLock {
+            if (!enabled || restored) {
+                null
+            } else {
+                CracResource(WeakReference(lifecycle), ::markRestored)
+            }
+        } ?: return null
+        Core.getGlobalContext().register(resource)
+        return resource
+    }
+
+    override fun configureHttpEngine(builder: HttpEngineConfig.Builder) {
+        builder.configureCheckpointRestore(isActive)
+    }
+
+    override fun createDefaultHttpEngine(): HttpClientEngine = createCheckpointRestoreAwareDefaultHttpEngine(isActive)
+
+    private fun markRestored() {
+        registrationLock.withLock {
+            restored = true
+        }
+    }
+}
+
+private class CracResource(
+    private val lifecycle: WeakReference<CheckpointRestoreLifecycle>,
+    private val markRestored: () -> Unit,
+) : Resource {
+    override fun beforeCheckpoint(context: Context<out Resource>) {
+        lifecycle.get()?.beforeCheckpoint()
+    }
+
+    override fun afterRestore(context: Context<out Resource>) {
+        try {
+            lifecycle.get()?.afterRestore()
+        } finally {
+            markRestored()
+        }
+    }
+}
+
+internal fun HttpEngineConfig.Builder.configureCheckpointRestore(enabled: Boolean) {
+    if (!enabled) {
+        return
+    }
+
+    val engine = buildHttpEngineConfig().httpClient
+    if (engine is SdkManagedCheckpointRestoreHttpClientEngine) {
+        return
+    }
+
+    val replacement = if (engine is SdkManaged && engine is CloseableHttpClientEngine) {
+        engine.replacementFactory()?.let {
+            SdkManagedCheckpointRestoreHttpClientEngine(CheckpointRestoreHttpClientEngine(engine, replacementFactory = it))
+        }
+    } else {
+        null
+    }
+
+    httpClient = replacement ?: engine
+}
+
+internal fun createCheckpointRestoreAwareDefaultHttpEngine(enabled: Boolean): HttpClientEngine {
+    val engine = DefaultHttpEngine()
+    if (!enabled) {
+        return engine
+    }
+
+    val replacementFactory = engine.replacementFactory() ?: return engine
+    return CheckpointRestoreHttpClientEngine(engine, replacementFactory = replacementFactory)
+}
+
+private fun HttpClientEngine.replacementFactory(): (() -> CloseableHttpClientEngine)? {
+    val contextClassLoader = Thread.currentThread().contextClassLoader
+    return when (val engineConfig = config) {
+        is OkHttpEngineConfig -> when (coroutineContext[CoroutineName]?.name) {
+            OKHTTP_ENGINE_NAME -> ({ OkHttpEngine(engineConfig) })
+            OKHTTP4_ENGINE_NAME -> ({ createOkHttp4Engine(engineConfig, contextClassLoader) })
+            else -> null
+        }
+        else -> null
+    }
+}
+
+private fun createOkHttp4Engine(
+    config: OkHttpEngineConfig,
+    classLoader: ClassLoader?,
+): CloseableHttpClientEngine {
+    val effectiveClassLoader = classLoader ?: CheckpointRestoreHttpClientEngine::class.java.classLoader
+    val engineClass = Class.forName(OKHTTP4_ENGINE_CLASS, true, effectiveClassLoader)
+    val constructor = engineClass.getConstructor(OkHttpEngineConfig::class.java)
+    return constructor.newInstance(config) as CloseableHttpClientEngine
+}
+
+internal class CheckpointRestoreHttpClientEngine(
+    initialEngine: CloseableHttpClientEngine,
+    private val checkpointQuiescenceTimeoutMillis: Long = CHECKPOINT_QUIESCENCE_TIMEOUT_MILLIS,
+    private val replacementFactory: () -> CloseableHttpClientEngine,
+) : CloseableHttpClientEngine {
+    private val lock = createCheckpointRestoreLock()
+    private var closed = false
+    private var checkpointed = false
+    private var currentEngine = initialEngine
+
+    override val config: HttpClientEngineConfig = initialEngine.config
+
+    @Suppress("unused")
+    private val checkpointRestoreLifecycle = if (isCheckpointRestoreEnvironment()) {
+        CheckpointRestoreLifecycle(::beforeCheckpoint, ::afterRestore).register()
+    } else {
+        null
+    }
+
+    override val coroutineContext: CoroutineContext
+        get() = lock.withLock { currentEngine.coroutineContext }
+
+    override suspend fun roundTrip(context: ExecutionContext, request: HttpRequest): HttpCall {
+        val engine = lock.withLock {
+            check(!checkpointed) { "HTTP engine is unavailable during a checkpoint" }
+            currentEngine
+        }
+        return engine.roundTrip(context, request)
+    }
+
+    override fun close() {
+        val engine = lock.withLock {
+            if (closed) {
+                return
+            }
+            closed = true
+            currentEngine
+        }
+        engine.close()
+    }
+
+    internal fun beforeCheckpoint() {
+        val engine = lock.withLock {
+            if (closed || checkpointed) {
+                return
+            }
+            checkpointed = true
+            currentEngine
+        }
+
+        try {
+            if (engine is SdkManaged) {
+                engine.unshare()
+            } else {
+                engine.close()
+            }
+            engine.coroutineContext[Job]?.let { job ->
+                runBlocking {
+                    withTimeout(checkpointQuiescenceTimeoutMillis) {
+                        job.join()
+                    }
+                }
+            }
+        } catch (ex: Exception) {
+            recoverFromFailedCheckpoint()
+            throw IllegalStateException("HTTP engine did not become idle before the checkpoint", ex)
+        }
+    }
+
+    internal fun afterRestore() {
+        lock.withLock {
+            if (closed || !checkpointed) {
+                return
+            }
+            currentEngine = replacementFactory()
+            checkpointed = false
+        }
+    }
+
+    private fun recoverFromFailedCheckpoint() {
+        lock.withLock {
+            if (closed || !checkpointed) {
+                return
+            }
+            currentEngine = replacementFactory()
+            checkpointed = false
+        }
+    }
+}
+
+internal class SdkManagedCheckpointRestoreHttpClientEngine(
+    private val delegate: CheckpointRestoreHttpClientEngine,
+) : SdkManagedBase(),
+    CloseableHttpClientEngine by delegate {
+    override fun unshare(): Boolean {
+        val shouldClose = super.unshare()
+        if (shouldClose) {
+            close()
+        }
+        return shouldClose
+    }
+
+    internal fun beforeCheckpoint(): Unit = delegate.beforeCheckpoint()
+
+    internal fun afterRestore(): Unit = delegate.afterRestore()
+}

--- a/aws-runtime/aws-config/jvm/test/aws/sdk/kotlin/runtime/auth/credentials/DefaultChainCredentialsProviderTest.kt
+++ b/aws-runtime/aws-config/jvm/test/aws/sdk/kotlin/runtime/auth/credentials/DefaultChainCredentialsProviderTest.kt
@@ -9,6 +9,7 @@ import aws.sdk.kotlin.runtime.auth.credentials.internal.credentials
 import aws.sdk.kotlin.runtime.http.interceptors.businessmetrics.withBusinessMetrics
 import aws.sdk.kotlin.runtime.util.toAwsCredentialsBusinessMetric
 import aws.smithy.kotlin.runtime.auth.awscredentials.Credentials
+import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProviderException
 import aws.smithy.kotlin.runtime.auth.awscredentials.copy
 import aws.smithy.kotlin.runtime.httptest.TestConnection
 import aws.smithy.kotlin.runtime.time.Instant
@@ -25,6 +26,7 @@ import java.io.File
 import java.nio.file.Paths
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 // TODO - refactor to make this work in common
@@ -252,6 +254,72 @@ class DefaultChainCredentialsProviderTest {
 
     @Test
     fun testPreferSystemProperties() = executeTest("prefer_system_properties")
+
+    @Test
+    fun testRefreshesCachedCredentialsAfterRestore() = runTest {
+        val environment = mutableMapOf(
+            "AWS_ACCESS_KEY_ID" to "before-access-key",
+            "AWS_SECRET_ACCESS_KEY" to "before-secret-key",
+        )
+        val platform = DefaultChainPlatformProvider(environment, emptyMap(), FsRootedAt(File(".")))
+        val provider = DefaultChainCredentialsProvider(platformProvider = platform, httpClient = TestConnection())
+
+        assertEquals("before-access-key", provider.resolve().accessKeyId)
+
+        environment["AWS_ACCESS_KEY_ID"] = "after-access-key"
+        environment["AWS_SECRET_ACCESS_KEY"] = "after-secret-key"
+        assertEquals("before-access-key", provider.resolve().accessKeyId)
+
+        provider.beforeCheckpoint()
+        provider.afterRestore()
+
+        assertEquals("after-access-key", provider.resolve().accessKeyId)
+        provider.close()
+    }
+
+    @Test
+    fun testCheckpointAndRestoreHooksArePairedAndIdempotent() = runTest {
+        val environment = mutableMapOf(
+            "AWS_ACCESS_KEY_ID" to "before-access-key",
+            "AWS_SECRET_ACCESS_KEY" to "before-secret-key",
+        )
+        val platform = DefaultChainPlatformProvider(environment, emptyMap(), FsRootedAt(File(".")))
+        val provider = DefaultChainCredentialsProvider(platformProvider = platform, httpClient = TestConnection())
+
+        assertEquals("before-access-key", provider.resolve().accessKeyId)
+        environment["AWS_ACCESS_KEY_ID"] = "after-access-key"
+        environment["AWS_SECRET_ACCESS_KEY"] = "after-secret-key"
+
+        provider.afterRestore()
+        assertEquals("before-access-key", provider.resolve().accessKeyId)
+
+        provider.beforeCheckpoint()
+        provider.beforeCheckpoint()
+        provider.afterRestore()
+        assertEquals("after-access-key", provider.resolve().accessKeyId)
+
+        environment["AWS_ACCESS_KEY_ID"] = "ignored-access-key"
+        provider.afterRestore()
+        assertEquals("after-access-key", provider.resolve().accessKeyId)
+        provider.close()
+    }
+
+    @Test
+    fun testResolveFailsDuringCheckpointAndClosePreventsRestore() = runTest {
+        val environment = mutableMapOf(
+            "AWS_ACCESS_KEY_ID" to "access-key",
+            "AWS_SECRET_ACCESS_KEY" to "secret-key",
+        )
+        val platform = DefaultChainPlatformProvider(environment, emptyMap(), FsRootedAt(File(".")))
+        val provider = DefaultChainCredentialsProvider(platformProvider = platform, httpClient = TestConnection())
+
+        provider.beforeCheckpoint()
+        assertFailsWith<CredentialsProviderException> { provider.resolve() }
+
+        provider.close()
+        provider.afterRestore()
+        assertFailsWith<CredentialsProviderException> { provider.resolve() }
+    }
 
     @Test
     fun testProfileName() = executeTest("profile_name")

--- a/aws-runtime/aws-config/jvm/test/aws/sdk/kotlin/runtime/config/CheckpointRestoreJVMTest.kt
+++ b/aws-runtime/aws-config/jvm/test/aws/sdk/kotlin/runtime/config/CheckpointRestoreJVMTest.kt
@@ -1,0 +1,229 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.sdk.kotlin.runtime.config
+
+import aws.smithy.kotlin.runtime.http.HttpCall
+import aws.smithy.kotlin.runtime.http.config.EngineFactory
+import aws.smithy.kotlin.runtime.http.engine.CloseableHttpClientEngine
+import aws.smithy.kotlin.runtime.http.engine.HttpClientEngineBase
+import aws.smithy.kotlin.runtime.http.engine.HttpClientEngineConfig
+import aws.smithy.kotlin.runtime.http.engine.HttpEngineConfigImpl
+import aws.smithy.kotlin.runtime.http.engine.okhttp.OkHttpEngine
+import aws.smithy.kotlin.runtime.http.engine.okhttp4.OkHttp4Engine
+import aws.smithy.kotlin.runtime.http.request.HttpRequest
+import aws.smithy.kotlin.runtime.io.SdkManaged
+import aws.smithy.kotlin.runtime.io.SdkManagedCloseable
+import aws.smithy.kotlin.runtime.io.SdkManagedGroup
+import aws.smithy.kotlin.runtime.io.addIfManaged
+import aws.smithy.kotlin.runtime.operation.ExecutionContext
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class CheckpointRestoreJVMTest {
+    @Test
+    fun testEngineRestartsAfterRestore() {
+        val initialEngine = TestEngine()
+        val replacementEngine = TestEngine()
+        var replacementCount = 0
+        val engine = CheckpointRestoreHttpClientEngine(initialEngine) {
+            replacementCount++
+            replacementEngine
+        }
+
+        assertTrue(engine.coroutineContext[Job]!!.isActive)
+
+        engine.beforeCheckpoint()
+
+        assertFalse(initialEngine.coroutineContext[Job]!!.isActive)
+        assertEquals(1, initialEngine.shutdownCount)
+
+        engine.afterRestore()
+
+        assertEquals(1, replacementCount)
+        assertTrue(engine.coroutineContext[Job]!!.isActive)
+
+        engine.close()
+        runBlocking { replacementEngine.coroutineContext[Job]!!.join() }
+        assertEquals(1, replacementEngine.shutdownCount)
+    }
+
+    @Test
+    fun testClosedEngineDoesNotRestart() {
+        val initialEngine = TestEngine()
+        var replacementCount = 0
+        val engine = CheckpointRestoreHttpClientEngine(initialEngine) {
+            replacementCount++
+            TestEngine()
+        }
+
+        engine.close()
+        runBlocking { initialEngine.coroutineContext[Job]!!.join() }
+        engine.beforeCheckpoint()
+        engine.afterRestore()
+
+        assertEquals(0, replacementCount)
+        assertEquals(1, initialEngine.shutdownCount)
+    }
+
+    @Test
+    fun testSdkManagedDefaultEngineIsWrapped() {
+        val builder = HttpEngineConfigImpl.BuilderImpl()
+
+        builder.configureCheckpointRestore(true)
+
+        val engine = assertIs<SdkManagedCheckpointRestoreHttpClientEngine>(builder.buildHttpEngineConfig().httpClient)
+        val initialJob = engine.coroutineContext[Job]!!
+
+        engine.beforeCheckpoint()
+        assertFalse(initialJob.isActive)
+        engine.afterRestore()
+        assertTrue(engine.coroutineContext[Job]!!.isActive)
+        engine.close()
+    }
+
+    @Test
+    fun testUnsupportedSdkManagedEngineRetainsManagedOwnership() {
+        val factory = UnsupportedManagedEngineFactory()
+        val builder = HttpEngineConfigImpl.BuilderImpl().apply {
+            httpClient(factory) { }
+        }
+
+        builder.configureCheckpointRestore(true)
+
+        val engine = builder.buildHttpEngineConfig().httpClient
+        assertIs<SdkManaged>(engine)
+        assertEquals(1, factory.engines.size)
+
+        SdkManagedGroup().apply {
+            addIfManaged(engine)
+            unshareAll()
+        }
+        assertEquals(1, factory.engines.single().shutdownCount)
+    }
+
+    @Test
+    fun testProviderOwnedDefaultEngineIsNotSdkManaged() {
+        val engine = createCheckpointRestoreAwareDefaultHttpEngine(true)
+
+        assertFalse(engine is SdkManaged)
+        assertIs<CheckpointRestoreHttpClientEngine>(engine)
+        engine.close()
+    }
+
+    @Test
+    fun testCallerOwnedEngineIsNotWrapped() {
+        val explicitEngine = OkHttpEngine()
+        val builder = HttpEngineConfigImpl.BuilderImpl().apply {
+            httpClient = explicitEngine
+        }
+
+        builder.configureCheckpointRestore(true)
+
+        assertSame(explicitEngine, builder.buildHttpEngineConfig().httpClient)
+        explicitEngine.close()
+    }
+
+    @Test
+    fun testSdkManagedOkHttp4EngineRetainsImplementationAfterRestore() {
+        val builder = HttpEngineConfigImpl.BuilderImpl().apply {
+            httpClient(OkHttp4Engine) { }
+        }
+
+        builder.configureCheckpointRestore(true)
+
+        val engine = assertIs<SdkManagedCheckpointRestoreHttpClientEngine>(builder.buildHttpEngineConfig().httpClient)
+        assertEquals("http-client-engine-OkHttp4-context", engine.coroutineContext[CoroutineName]?.name)
+
+        engine.beforeCheckpoint()
+        engine.afterRestore()
+
+        assertEquals("http-client-engine-OkHttp4-context", engine.coroutineContext[CoroutineName]?.name)
+        engine.close()
+    }
+
+    @Test
+    fun testCheckpointWaitsForActiveRequests() {
+        val initialEngine = TestEngine()
+        val child = CoroutineScope(initialEngine.coroutineContext).launch {
+            delay(25)
+        }
+        val engine = CheckpointRestoreHttpClientEngine(initialEngine, replacementFactory = ::TestEngine)
+
+        engine.beforeCheckpoint()
+
+        assertTrue(child.isCompleted)
+        assertEquals(1, initialEngine.shutdownCount)
+        engine.afterRestore()
+        engine.close()
+    }
+
+    @Test
+    fun testQuiescenceFailureAbortsCheckpointAndRestoresUsableEngine() {
+        val initialEngine = TestEngine()
+        val replacementEngine = TestEngine()
+        val child = CoroutineScope(initialEngine.coroutineContext).launch {
+            delay(Long.MAX_VALUE)
+        }
+        val engine = CheckpointRestoreHttpClientEngine(
+            initialEngine,
+            replacementFactory = { replacementEngine },
+            checkpointQuiescenceTimeoutMillis = 1,
+        )
+
+        assertFailsWith<IllegalStateException> { engine.beforeCheckpoint() }
+        assertSame(replacementEngine.coroutineContext, engine.coroutineContext)
+        assertTrue(engine.coroutineContext[Job]!!.isActive)
+
+        child.cancel()
+        engine.close()
+        runBlocking {
+            initialEngine.coroutineContext[Job]!!.join()
+            replacementEngine.coroutineContext[Job]!!.join()
+        }
+        assertEquals(1, initialEngine.shutdownCount)
+        assertEquals(1, replacementEngine.shutdownCount)
+    }
+}
+
+private class UnsupportedManagedEngineFactory : EngineFactory<HttpClientEngineConfig.Builder, UnsupportedManagedEngine> {
+    val engines = mutableListOf<TestEngine>()
+
+    override val engineConstructor: (HttpClientEngineConfig.Builder.() -> Unit) -> UnsupportedManagedEngine = {
+        val delegate = TestEngine()
+        engines += delegate
+        UnsupportedManagedEngine(delegate)
+    }
+}
+
+private class UnsupportedManagedEngine(
+    private val delegate: TestEngine,
+) : SdkManagedCloseable(delegate),
+    CloseableHttpClientEngine by delegate
+
+private class TestEngine : HttpClientEngineBase("checkpoint-restore-test") {
+    override val config: HttpClientEngineConfig = HttpClientEngineConfig.Default
+    var shutdownCount: Int = 0
+
+    override suspend fun roundTrip(
+        context: ExecutionContext,
+        request: HttpRequest,
+    ): HttpCall = error("not used")
+
+    override fun shutdown() {
+        shutdownCount++
+    }
+}

--- a/aws-runtime/aws-config/native/src/aws/sdk/kotlin/runtime/config/CheckpointRestoreNative.kt
+++ b/aws-runtime/aws-config/native/src/aws/sdk/kotlin/runtime/config/CheckpointRestoreNative.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.sdk.kotlin.runtime.config
+
+import aws.smithy.kotlin.runtime.http.config.HttpEngineConfig
+import aws.smithy.kotlin.runtime.http.engine.DefaultHttpEngine
+import aws.smithy.kotlin.runtime.http.engine.HttpClientEngine
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+
+internal actual val checkpointRestorePlatform: CheckpointRestorePlatform = NoOpCheckpointRestorePlatform()
+
+internal actual fun createCheckpointRestoreLock(): CheckpointRestoreLock = NativeCheckpointRestoreLock()
+
+@OptIn(ExperimentalAtomicApi::class)
+private class NativeCheckpointRestoreLock : CheckpointRestoreLock {
+    private val state = AtomicInt(0)
+
+    override fun lock() {
+        var acquired: Boolean
+        do {
+            acquired = state.compareAndSet(0, 1)
+        } while (!acquired)
+    }
+
+    override fun unlock() {
+        check(state.compareAndSet(1, 0)) { "Checkpoint/restore lock is not held" }
+    }
+}
+
+private class NoOpCheckpointRestorePlatform : CheckpointRestorePlatform() {
+    override val isActive: Boolean = false
+
+    override fun register(lifecycle: CheckpointRestoreLifecycle): Any? = null
+
+    override fun configureHttpEngine(builder: HttpEngineConfig.Builder) { }
+
+    override fun createDefaultHttpEngine(): HttpClientEngine = DefaultHttpEngine()
+}

--- a/docs/howto/README.md
+++ b/docs/howto/README.md
@@ -7,3 +7,4 @@ This documentation supplements the official [AWS SDK for Kotlin Developer Guide]
 
 * [Endpoints](./configuring/endpoints.md) - How to configure a custom endpoint resolver
 * [Http Clients](./configuring/http-clients.md) - How to specify an alternative HTTP client
+* [Lambda SnapStart](./configuring/lambda-snapstart.md) - How the SDK prepares clients for checkpoint and restore

--- a/docs/howto/configuring/lambda-snapstart.md
+++ b/docs/howto/configuring/lambda-snapstart.md
@@ -1,0 +1,36 @@
+# Configuring AWS Lambda SnapStart
+
+The AWS SDK for Kotlin automatically prepares its default JVM resources for AWS Lambda SnapStart. No SDK-specific
+configuration is required. When Lambda sets `AWS_LAMBDA_INITIALIZATION_TYPE=snap-start`, SDK clients created during the
+function initialization phase register checkpoint and restore hooks through the CRaC API.
+
+Create reusable SDK clients outside the invocation handler so that client construction is included in the snapshot:
+
+```kotlin
+class Handler : RequestHandler<Unit, String> {
+    private val s3 = S3Client { region = "us-east-1" }
+
+    override fun handleRequest(input: Unit, context: Context): String = runBlocking {
+        s3.listBuckets().buckets.orEmpty().joinToString { it.name.orEmpty() }
+    }
+}
+```
+
+Before Lambda creates the snapshot, the SDK closes its default credential provider chain, resets the default bearer-token
+provider's loaded configuration, and shuts down SDK-managed OkHttp engines. After Lambda restores the function, the SDK
+recreates those resources. This discards credentials cached before the snapshot and avoids reusing HTTP connection-pool
+state captured at checkpoint.
+
+Before Lambda creates the snapshot, the SDK stops accepting new requests and waits up to ten seconds for active requests
+to finish before closing its default HTTP engine. Complete initialization-time SDK calls before the checkpoint whenever
+possible. If requests do not become idle within the timeout, checkpoint creation fails and the SDK recreates the engine
+so the initialization environment remains usable.
+
+The default OkHttp engine and the SDK-managed OkHttp4 engine are restored automatically. Other SDK-managed engines,
+including CRT, are not restored automatically. Resources explicitly supplied in client configuration remain caller-owned.
+If you configure another HTTP engine, credentials provider, or bearer-token provider, register any required CRaC hooks
+for that resource yourself.
+
+SnapStart still establishes network connections and resolves credentials as needed after restore. Consult the
+[AWS Lambda SnapStart documentation](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html) for supported runtimes,
+deployment configuration, and restore-time constraints.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ aws-kotlin-repo-tools-version = "0.6.3"
 coroutines-version = "1.11.0"
 atomicfu-version = "0.33.0"
 binary-compatibility-validator-version = "0.18.2"
+crac-version = "1.5.0"
 
 # smithy-kotlin
 smithy-kotlin-version = "1.7.9"
@@ -46,6 +47,7 @@ kotlinx-atomicfu-plugin = { module = "org.jetbrains.kotlinx:atomicfu-gradle-plug
 
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines-version" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines-version" }
+crac = { module = "org.crac:crac", version.ref = "crac-version" }
 
 ksp-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp-version" }
 ksp-gradle-plugin = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp-version" }


### PR DESCRIPTION
## Issue #

Couldn't find any external request for SnapStart support.

## Description of changes

Adds automatic checkpoint and restore handling for AWS SDK for Kotlin clients running with AWS Lambda SnapStart.

When Lambda enables SnapStart, the SDK now registers CRaC lifecycle resources that:

- Close and recreate the default credentials and bearer-token provider chains, preventing cached credentials from being retained in the snapshot.
- Quiesce and recreate SDK-managed HTTP engines, avoiding the reuse of connection pools and other network state captured during checkpointing.
- Support both the default OkHttp 5 engine and the OkHttp 4 compatibility engine.
- Abort checkpoint creation and restore usable state when an HTTP engine or provider cannot be prepared safely.
- Leave explicitly supplied engines and providers under the caller’s lifecycle management.

The CRaC integration is JVM-specific. Other Kotlin Multiplatform targets use a no-op implementation and retain their existing behaviour.

This change also adds lifecycle and concurrency tests, API compatibility coverage, and documentation describing SnapStart behavior and resource ownership.

### Benchmark validation

We compared SnapStart with and without this change using Java 21 Lambda functions at 512 MB. Each architecture used ten paired samples with a fresh published version. The primary metric was Lambda restore duration plus first-invocation duration. Each Lambda initialised a default DynamoDbClient and DynamoDbMapper, then used both before checkpoint and after restore to read a unique UUID and, when absent, write a five-field DynamoDB item containing string, number, and boolean values.

| Architecture | Baseline | With change | Difference | Paired 95% CI |
|---|---:|---:|---:|---:|
| x86_64 | 1,426 ms | 1,405 ms | 21 ms faster (1.47%) | -39 to 81 ms |
| ARM64 | 1,434 ms | 1,334 ms | 100 ms faster (6.98%) | -70 to 270 ms |

Both intervals include zero, so the benchmark shows no statistically significant performance change. Likely, heavier cases where more clients are instantiated would yield a clearer benefit. All 40 invocations succeeded, all 80 post-restore DynamoDB read/write workflows completed, all 160 items were verified, and CRaC lifecycle execution was confirmed for every fixed version.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.